### PR TITLE
Make profiling feature compatible with a loqusdb-v1 database.

### DIFF
--- a/loqusdb/utils/profiling.py
+++ b/loqusdb/utils/profiling.py
@@ -94,6 +94,9 @@ def profile_match(adapter, profiles, hard_threshold=0.95, soft_threshold=0.9):
     matches = {sample: [] for sample in profiles.keys()}
     for case in adapter.cases():
 
+        if case.get('individuals') is None:
+            continue
+
         for individual in case['individuals']:
 
             for sample in profiles.keys():


### PR DESCRIPTION
Fix taking into account that older versions of loqusdb does not have an
'individuals' property in 'case' collection.