### PR TITLE
Add option to check for duplicates

### DIFF
--- a/loqusdb/commands/load_profile.py
+++ b/loqusdb/commands/load_profile.py
@@ -54,7 +54,10 @@ def load_profile(ctx, variant_file, update, stats, profile_threshold, check_vcf)
 
     adapter = ctx.obj['adapter']
 
+    LOG.info("Running loqusdb profile")
+
     if check_vcf:
+        LOG.info(f"Check if profile in {check_vcf} has match in database")
         vcf_file = check_vcf
         profiles = get_profiles(adapter, vcf_file)
         duplicate = check_duplicates(adapter, profiles, profile_threshold)
@@ -62,15 +65,19 @@ def load_profile(ctx, variant_file, update, stats, profile_threshold, check_vcf)
         if duplicate is not None:
             duplicate = json.dumps(duplicate)
             click.echo(duplicate)
+        else:
+            LOG.info("No duplicates found in the database")
 
     if variant_file:
+        LOG.info(f"Loads variants in {variant_file} to be used in profiling")
         load_profile_variants(adapter, variant_file)
 
     if update:
+        LOG.info("Updates profiles in database")
         update_profiles(adapter)
 
     if stats:
-
+        LOG.info("Prints profile stats")
         distance_dict = profile_stats(adapter, threshold=profile_threshold)
         click.echo(table_from_dict(distance_dict))
 

--- a/loqusdb/utils/profiling.py
+++ b/loqusdb/utils/profiling.py
@@ -126,6 +126,45 @@ def profile_match(adapter, profiles, hard_threshold=0.95, soft_threshold=0.9):
 
     return matches
 
+def check_duplicates(adapter, profiles, hard_threshold):
+
+    """
+        Searches database for duplicates. If duplicate is found, the individual
+        is returned.
+
+        Args:
+            adapter (MongoAdapter): Adapter to mongodb
+            profiles (dict(str)): The profiles (given as strings) for each sample in vcf.
+            hard_threshold(float): Rejects load if hamming distance above this is found
+        Returns:
+            individual (dict): dictionary representation of duplicated individual
+
+    """
+
+    for case in adapter.cases():
+
+        if case.get('individuals') is None:
+            continue
+
+        for individual in case['individuals']:
+
+            for sample in profiles.keys():
+
+                if individual.get('profile'):
+
+                    similarity = compare_profiles(
+                        profiles[sample], individual['profile']
+                    )
+
+                    if similarity >= hard_threshold:
+
+                        msg = (
+                                f"individual {sample} has a {similarity} similarity "
+                                f"with individual {individual['ind_id']} in case "
+                                f"{case['case_id']}"
+                        )
+                        LOG.info(msg)
+                        return individual
 
 
 def compare_profiles(profile1, profile2):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -187,11 +187,11 @@ def sv_vcf_obj(request, sv_vcf_path):
     return cyvcf2.VCF(sv_vcf_path)
 
 @pytest.fixture(scope='function')
-def profile_str(request):
-    return 'AACCGGTT'
+def profile_list(request):
+    return ['AA', 'CC', 'GG', 'TT']
 
 @pytest.fixture(scope='function')
-def case_obj(request, case_lines, vcf_obj, vcf_path, profile_str):
+def case_obj(request, case_lines, vcf_obj, vcf_path, profile_list):
     """Return a case obj"""
     family_parser = FamilyParser(case_lines, family_type='ped')
     families = list(family_parser.families.keys())
@@ -205,7 +205,7 @@ def case_obj(request, case_lines, vcf_obj, vcf_path, profile_str):
         vcf_individuals=vcf_individuals,
         vcf_path=vcf_path,
         nr_variants=nr_variants,
-        profiles={individual: profile_str for individual in vcf_individuals}
+        profiles={individual: profile_list for individual in vcf_individuals}
         )
     return _case_obj
 

--- a/tests/utils/test_profiling.py
+++ b/tests/utils/test_profiling.py
@@ -1,6 +1,9 @@
 import pytest
 
-from loqusdb.utils.profiling import (get_profiles, profile_match, compare_profiles)
+from loqusdb.utils.profiling import (get_profiles,
+                                     profile_match,
+                                     compare_profiles,
+                                     check_duplicates)
 from loqusdb.utils.load import (load_profile_variants, load_case)
 from loqusdb.utils.vcf import check_vcf
 
@@ -25,24 +28,48 @@ def test_get_profiles(real_mongo_adapter, profile_vcf_path, zipped_vcf_path):
         assert len(profiles[individual]) == length
 
 
-def test_profile_match(real_mongo_adapter, profile_vcf_path, profile_str, case_obj):
+def test_profile_match(real_mongo_adapter, profile_vcf_path, profile_list, case_obj):
 
     #Load profile variants
     load_profile_variants(real_mongo_adapter, profile_vcf_path)
 
-    #Load case having profiles profile_str
+    #Load case having profiles profile_list
     load_case(real_mongo_adapter, case_obj)
 
     #Get profiles from vcf
-    profiles = {'test_individual': profile_str}
+    profiles = {'test_individual': profile_list}
 
     #Assert that error is raised
     with pytest.raises(ProfileError) as error:
 
         profile_match(real_mongo_adapter, profiles)
 
+
+def test_check_duplicates(real_mongo_adapter, profile_vcf_path, profile_list, case_obj):
+
+    # Load profile variants
+    load_profile_variants(real_mongo_adapter, profile_vcf_path)
+    # Load case having profiles profile_list
+    load_case(real_mongo_adapter, case_obj)
+    # Create profiles dictionary
+    profiles = {'test_individual': profile_list}
+    # match profiles to the profiles in the database
+    match = check_duplicates(real_mongo_adapter, profiles, hard_threshold=0.95)
+    # This should match with the sample in the database
+    assert match['profile'] == profile_list
+
+    # Change last genotype, now no matches should be found
+    profiles = {'test_individual': profile_list[:-1] + ['NN']}
+    match = check_duplicates(real_mongo_adapter, profiles, hard_threshold=0.80)
+    assert match is None
+
+    # Lower threshold. Now match should be found
+    match = check_duplicates(real_mongo_adapter, profiles, hard_threshold=0.75)
+    assert match['profile'] == profile_list
+
 def test_compare_profiles():
 
-    assert compare_profiles('AACC', 'AACC') == 1
-    assert compare_profiles('AACC', 'GGCC') == 0.5
-    assert compare_profiles('ACCG', 'TCCG') == 0.75
+    assert compare_profiles(['AA', 'CC'], ['AA', 'CC']) == 1.0
+    assert compare_profiles(['AA', 'CC'], ['GG', 'CC']) == 0.5
+    assert compare_profiles(['AC', 'CG'], ['TC', 'CG']) == 0.5
+    assert compare_profiles(['AC', 'GT'], ['AA', 'GG']) == 0.0


### PR DESCRIPTION
The CLI option 'loqusdb profile --check-vcf' is now added. This will
check the profile of the vcf given for '--check-vcf', and see if it
matches any individual in the database. If a match is found, the
individual is printed to stdout as a json string.