### PR TITLE
This PR tries to solve several issues regarding the 'delete' feature in loqusdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ a set of high maf variants.
 - High maf variants used in profiling is loaded into DB via CLI
 - Reject loading a case if a similar profile already exists for any of the samples
 - Statistics of the profiles in DB can be generated through CLI
+- use bulk operations when deleting variants
 
 ## [2.3]
 

--- a/loqusdb/commands/delete.py
+++ b/loqusdb/commands/delete.py
@@ -54,7 +54,7 @@ def delete(ctx, family_file, family_type, case_id):
     existing_case = adapter.case({'case_id': case_id})
     if not existing_case:
         LOG.warning("Case %s does not exist in database" %case_id)
-        context.abort
+        ctx.abort()
 
 
     start_deleting = datetime.now()

--- a/loqusdb/commands/delete.py
+++ b/loqusdb/commands/delete.py
@@ -54,7 +54,7 @@ def delete(ctx, family_file, family_type, case_id):
     existing_case = adapter.case({'case_id': case_id})
     if not existing_case:
         LOG.warning("Case %s does not exist in database" %case_id)
-        ctx.abort()
+        return
 
 
     start_deleting = datetime.now()

--- a/loqusdb/plugins/mongo/structural_variant.py
+++ b/loqusdb/plugins/mongo/structural_variant.py
@@ -188,6 +188,21 @@ class SVMixin():
         return
 
     def _update_sv_metrics(self, sv_type, pos_mean, end_mean, max_window):
+
+        """
+            calculates cluster length, and interval size for SV based on
+            mean start position and mean end position.
+
+            Args:
+                sv_type (str): type of structural variant
+                pos_mean (int): mean start position for cluster
+                end_mean (int): mean end position of cluster
+                max_window (int): maximum interval size given in base pairs
+
+            Returns:
+                cluster_len (int): length of cluster
+                interval_size (int): interval size around start and end positions
+        """
         # We need to calculate the new cluster length
         # Handle translocation as a special case
         if sv_type != 'BND':

--- a/loqusdb/plugins/mongo/structural_variant.py
+++ b/loqusdb/plugins/mongo/structural_variant.py
@@ -13,23 +13,23 @@ class SVMixin():
 
     def add_structural_variant(self, variant, max_window = 3000):
         """Add a variant to the structural variants collection
-        
-        The process of adding an SV variant differs quite a bit from the 
+
+        The process of adding an SV variant differs quite a bit from the
         more straight forward case of SNV/INDEL.
-        
+
         Variants are represented in the database by clusters that are two intervals,
         one interval for start(pos) and one for end. The size of the intervals changes
         according to the size of the variants. The maximum window size is a parameter.
-        
+
         Here we need to search if the variant matches any of the existing
         clusters. Then we need to choose the closest cluster and update
         the boundaries for that cluster.
-        
+
         Args:
             variant (dict): A variant dictionary
             max_window(int): Specify the maximum window size for large svs
-        
-        
+
+
                                         -
                                       -   -
                                     -       -
@@ -56,13 +56,13 @@ class SVMixin():
                 'length': 0,
                 'sv_type': variant['sv_type'],
                 'families': [],
-                
+
             }
             # Insert variant to get a _id
             _id = self.db.structural_variant.insert_one(cluster).inserted_id
-            
+
             cluster['_id'] = _id
-        
+
         case_id = variant.get('case_id')
         if case_id:
             # If the variant is already added for this case we continue
@@ -77,7 +77,7 @@ class SVMixin():
 
         # Update number of times we have seen the event
         nr_events = cluster['observations'] + 1
-        
+
         #                             -
         #                           -   -
         #                         -       -
@@ -85,13 +85,13 @@ class SVMixin():
         #                     -               -
         #                   -                   -
         #                |--.--|              |--.--|
-    
+
         # This indicates the center for each of the end points for the event AFTER the new variant
         # is added to the cluster
         # i.e. the dots in the picture above
         pos_mean = int((cluster['pos_sum'] + variant['pos']) // (nr_events))
         end_mean = int((cluster['end_sum'] + variant['end']) // (nr_events))
-        
+
         # We need to calculate the new cluster length
         # Handle translocation as a special case
         if cluster['sv_type'] != 'BND':
@@ -111,8 +111,8 @@ class SVMixin():
             cluster_len = 10e10
             # This number seems large, if compared with SV size it is fairly small.
             interval_size = max_window * 2
-        
-        # If the length of SV is shorter than 500 the variant 
+
+        # If the length of SV is shorter than 500 the variant
         # is considered precise
         # Otherwise the interval size is closest whole 100 number
         res = self.db.structural_variant.find_one_and_update(
@@ -123,7 +123,7 @@ class SVMixin():
                     'pos_sum': variant['pos'],
                     'end_sum': variant['end'],
                 },
-            
+
                 '$set': {
                     'pos_left': max(pos_mean - interval_size, 0),
                     'pos_right': pos_mean + interval_size,
@@ -134,12 +134,92 @@ class SVMixin():
                 }
             }
         )
-        
+
         # Insert an identity object to link cases to variants and clusters
-        identity_obj = Identity(cluster_id=cluster['_id'], variant_id=variant['id_column'], 
+        identity_obj = Identity(cluster_id=cluster['_id'], variant_id=variant['id_column'],
                                 case_id=case_id)
         self.db.identity.insert_one(identity_obj)
-        
+
+        return
+
+    def delete_structural_variant(self, variant, max_window = 3000):
+
+        # This will return the cluster most similar to variant or None
+        cluster = self.get_structural_variant(variant)
+
+        if cluster is None:
+            return
+
+        case_id = variant.get('case_id')
+
+        if case_id in cluster['families']:
+            # Insert the new case in the beginning of array
+            cluster['families'].remove(case_id)
+
+        nr_events = cluster['observations'] - 1
+
+        if nr_events == 0:
+            # Remove SV if no observations remain
+            self.db.structural_variant.delete_one({'_id': cluster['_id']})
+
+            # remove identiry
+            identity_obj = Identity(cluster_id=cluster['_id'], variant_id=variant['id_column'],
+                                    case_id=case_id)
+            self.db.identity.delete_one(identity_obj)
+
+            return
+
+        pos_mean = int((cluster['pos_sum'] - variant['pos']) // (nr_events))
+        end_mean = int((cluster['end_sum'] - variant['end']) // (nr_events))
+
+        # We need to calculate the new cluster length
+        # Handle translocation as a special case
+        if cluster['sv_type'] != 'BND':
+            cluster_len = end_mean - pos_mean
+            # We need to adapt the interval size depending on the size of the cluster
+            divider = 10
+            if cluster_len < 1000:
+                # We allow intervals for smaller variants to be relatively larger
+                divider = 2
+            elif cluster_len < 1000:
+                # We allow intervals for smaller variants to be relatively larger
+                divider = 5
+            interval_size = int(min(round(cluster_len/divider, -2), max_window))
+        else:
+            # We need to treat translocations as a special case.
+            # Set length to a huge number that mongodb can handle, float('inf') would not work.
+            cluster_len = 10e10
+            # This number seems large, if compared with SV size it is fairly small.
+            interval_size = max_window * 2
+
+        # If the length of SV is shorter than 500 the variant
+        # is considered precise
+        # Otherwise the interval size is closest whole 100 number
+        res = self.db.structural_variant.find_one_and_update(
+            {'_id': cluster['_id']},
+            {
+                '$inc': {
+                    'observations': -1,
+                    'pos_sum': -variant['pos'],
+                    'end_sum': -variant['end'],
+                },
+
+                '$set': {
+                    'pos_left': max(pos_mean - interval_size, 0),
+                    'pos_right': pos_mean + interval_size,
+                    'end_left': max(end_mean - interval_size, 0),
+                    'end_right': end_mean + interval_size,
+                    'families': cluster['families'],
+                    'length': cluster_len,
+                }
+            }
+        )
+
+        # Insert an identity object to link cases to variants and clusters
+        identity_obj = Identity(cluster_id=cluster['_id'], variant_id=variant['id_column'],
+                                case_id=case_id)
+        self.db.identity.delete_one(identity_obj)
+
         return
 
     def get_structural_variant(self, variant):
@@ -174,7 +254,7 @@ class SVMixin():
         # Then we count the distance to mean on both ends to see which variant is closest
         for hit in res:
             # We know from the query that the variants position is larger than the left most part of
-            # the cluster. 
+            # the cluster.
             # If the right most part of the cluster is smaller than the variant position they do
             # not overlap
             if hit['end_left'] > variant['end']:
@@ -183,7 +263,7 @@ class SVMixin():
                 continue
 
             # We need to calculate the distance to see what cluster that was closest to the variant
-            distance = (abs(variant['pos'] - (hit['pos_left'] + hit['pos_right'])/2) + 
+            distance = (abs(variant['pos'] - (hit['pos_left'] + hit['pos_right'])/2) +
                         abs(variant['end'] - (hit['end_left'] + hit['end_right'])/2))
 
             # If we have no cluster yet we set the curent to be the hit
@@ -201,7 +281,7 @@ class SVMixin():
 
         return match
 
-    def get_sv_variants(self, chromosome=None, end_chromosome=None, sv_type=None, 
+    def get_sv_variants(self, chromosome=None, end_chromosome=None, sv_type=None,
                         pos=None, end=None):
         """Return all structural variants in the database
 
@@ -216,7 +296,7 @@ class SVMixin():
             variants (Iterable(Variant))
         """
         query = {}
-        
+
         if chromosome:
             query['chrom'] = chromosome
         if end_chromosome:
@@ -228,23 +308,23 @@ class SVMixin():
                 query['$and'] = []
             query['$and'].append({'pos_left': {'$lte': pos}})
             query['$and'].append({'pos_right': {'$gte': pos}})
-            
+
         if end:
             if not '$and' in query:
                 query['$and'] = []
             query['$and'].append({'end_left': {'$lte': end}})
             query['$and'].append({'end_right': {'$gte': end}})
-        
+
         LOG.info("Find all sv variants {}".format(query))
-        
+
         return self.db.structural_variant.find(query).sort([('chrom', ASCENDING), ('pos_left', ASCENDING)])
 
     def get_clusters(self, variant_id):
         """Search what clusters a variant belongs to
-        
+
         Args:
             variant_id(str): From ID column in vcf
-        
+
         Returns:
             clusters()
         """

--- a/loqusdb/plugins/mongo/structural_variant.py
+++ b/loqusdb/plugins/mongo/structural_variant.py
@@ -197,7 +197,7 @@ class SVMixin():
             if cluster_len < 1000:
                 # We allow intervals for smaller variants to be relatively larger
                 divider = 2
-            elif cluster_len < 1000:
+            elif cluster_len < 10000:
                 # We allow intervals for smaller variants to be relatively larger
                 divider = 5
             interval_size = int(min(round(cluster_len/divider, -2), max_window))

--- a/loqusdb/plugins/mongo/variant.py
+++ b/loqusdb/plugins/mongo/variant.py
@@ -248,7 +248,7 @@ class VariantMixin(BaseVariantMixin, SVMixin):
             )
         # Make the accumulated write operations
         if len(operations) > 0:
-            self.db.variant.bulk_write(operations)
+            self.db.variant.bulk_write(operations, ordered=False)
 
     def get_chromosomes(self, sv=False):
         """Return a list of all chromosomes found in database

--- a/loqusdb/utils/delete.py
+++ b/loqusdb/utils/delete.py
@@ -11,14 +11,14 @@ LOG = logging.getLogger(__name__)
 
 def delete(adapter, case_obj, update=False, existing_case=False):
     """Delete a case and all of it's variants from the database.
-    
+
     Args:
         adapter: Connection to database
         case_obj(models.Case)
         update(bool): If we are in the middle of an update
         existing_case(models.Case): If something failed during an update we need to revert
                                     to the original case
-    
+
     """
     # This will overwrite the updated case with the previous one
     if update:
@@ -26,28 +26,37 @@ def delete(adapter, case_obj, update=False, existing_case=False):
     else:
         adapter.delete_case(case_obj)
 
-    for file_type in ['vcf_path','vcf_sv_path']:
+    for file_type in ['vcf_path', 'vcf_sv_path']:
         if not case_obj.get(file_type):
             continue
         variant_file = case_obj[file_type]
         # Get a cyvcf2.VCF object
         vcf_obj = get_vcf(variant_file)
 
-        delete_variants(
-            adapter=adapter,
-            vcf_obj=vcf_obj,
-            case_obj=case_obj,
-        )
+        if file_type == 'vcf_path':
+            LOG.info('deleting variants')
+            delete_variants(
+                adapter=adapter,
+                vcf_obj=vcf_obj,
+                case_obj=case_obj,
+            )
+        if file_type == 'vcf_sv_path':
+            LOG.info('deleting structural variants')
+            delete_structural_variants(
+                adapter=adapter,
+                vcf_obj=vcf_obj,
+                case_obj=case_obj,
+            )
 
 def delete_variants(adapter, vcf_obj, case_obj, case_id=None):
     """Delete variants for a case in the database
-    
+
     Args:
         adapter(loqusdb.plugins.Adapter)
         vcf_obj(iterable(dict))
         ind_positions(dict)
         case_id(str)
-    
+
     Returns:
         nr_deleted (int): Number of deleted variants
     """
@@ -57,27 +66,35 @@ def delete_variants(adapter, vcf_obj, case_obj, case_id=None):
     chrom_time = datetime.now()
     current_chrom = None
     new_chrom = None
-    
+
+    variant_list = []
     for variant in vcf_obj:
         formated_variant = build_variant(
             variant=variant,
             case_obj=case_obj,
             case_id=case_id,
         )
-        
+
         if not formated_variant:
             continue
-        
+
+        variant_list.append(formated_variant)
+
         new_chrom = formated_variant.get('chrom')
-        adapter.delete_variant(formated_variant)
+        # When there are enough variants in the variant list
+        # They are passed to delete_variants
+        if len(variant_list) == 10000:
+            adapter.delete_variants(variant_list)
+            variant_list.clear()
+
         nr_deleted += 1
-        
+
         if not current_chrom:
             LOG.info("Start deleting chromosome {}".format(new_chrom))
             current_chrom = new_chrom
             chrom_time = datetime.now()
             continue
-        
+
         if new_chrom != current_chrom:
             LOG.info("Chromosome {0} done".format(current_chrom))
             LOG.info("Time to delete chromosome {0}: {1}".format(
@@ -85,5 +102,56 @@ def delete_variants(adapter, vcf_obj, case_obj, case_id=None):
             LOG.info("Start deleting chromosome {0}".format(new_chrom))
             current_chrom = new_chrom
 
+    if len(variant_list) > 0:
+        adapter.delete_variants(variant_list)
+        variant_list.clear()
+
+    return nr_deleted
+
+def delete_structural_variants(adapter, vcf_obj, case_obj, case_id=None):
+    """Delete structural variants for a case in the database
+
+    Args:
+        adapter(loqusdb.plugins.Adapter)
+        vcf_obj(iterable(dict))
+        ind_positions(dict)
+        case_id(str)
+
+    Returns:
+        nr_deleted (int): Number of deleted variants"""
+
+    case_id = case_id or case_obj['case_id']
+    nr_deleted = 0
+    start_deleting = datetime.now()
+    chrom_time = datetime.now()
+    current_chrom = None
+    new_chrom = None
+
+    for variant in vcf_obj:
+        formated_variant = build_variant(
+            variant=variant,
+            case_obj=case_obj,
+            case_id=case_id,
+        )
+
+        if not formated_variant:
+            continue
+
+        new_chrom = formated_variant.get('chrom')
+        adapter.delete_structural_variant(formated_variant)
+        nr_deleted += 1
+
+        if not current_chrom:
+            LOG.info("Start deleting chromosome {}".format(new_chrom))
+            current_chrom = new_chrom
+            chrom_time = datetime.now()
+            continue
+
+        if new_chrom != current_chrom:
+            LOG.info("Chromosome {0} done".format(current_chrom))
+            LOG.info("Time to delete chromosome {0}: {1}".format(
+                current_chrom, datetime.now()-chrom_time))
+            LOG.info("Start deleting chromosome {0}".format(new_chrom))
+            current_chrom = new_chrom
 
     return nr_deleted

--- a/tests/plugins/mongo/test_variant_operations.py
+++ b/tests/plugins/mongo/test_variant_operations.py
@@ -1,4 +1,8 @@
+import copy
+
 from loqusdb.plugins import MongoAdapter
+from loqusdb.build_models import build_variant
+
 
 class TestInsertVariant:
 
@@ -186,3 +190,60 @@ class TestRemoveVariant:
         mongo_adapter.delete_variant(simplest_variant)
 
         assert db.variant.find_one() == None
+
+class TestRemoveSV:
+
+    def test_remove_one_SV(self, mongo_adapter, del_variant, case_obj):
+
+        # GIVEN a database poulated with one SV
+        db = mongo_adapter.db
+        formated_variant = build_variant(del_variant, case_obj=case_obj, case_id=case_obj['case_id'])
+        mongo_adapter.add_structural_variant(formated_variant)
+        mongo_SV = db.structural_variant.find_one()
+        mongo_identity = db.identity.find_one()
+        assert mongo_SV is not None
+        assert mongo_identity is not None
+        # WHEN deleting SV
+        mongo_adapter.delete_structural_variant(formated_variant)
+
+        # THEN there should be no remaining SVs in the database
+        mongo_SV = db.structural_variant.find_one()
+        mongo_identity = db.indentity.find_one()
+        assert mongo_SV is None
+        assert mongo_identity is None
+
+    def test_remove_one_of_two_SV(self, mongo_adapter, duptandem_variant, case_obj):
+
+        # GIVEN a database poulated with one SV
+        db = mongo_adapter.db
+        formated_variant = build_variant(duptandem_variant, case_obj=case_obj, case_id=case_obj['case_id'])
+        mongo_adapter.add_structural_variant(formated_variant)
+
+        # Add second of same variant, changing the start and end position slightly
+        formated_variant_ = copy.deepcopy(formated_variant)
+        formated_variant_['pos'] = formated_variant_['pos']+2
+        formated_variant_['end'] = formated_variant_['end']-1
+        formated_variant_['case_id'] = 'case_2'
+        mongo_adapter.add_structural_variant(formated_variant_)
+
+        # This should correspond to one structural variant document
+        mongo_svs = list(db.structural_variant.find())
+        assert len(mongo_svs) == 1
+        mongo_sv = mongo_svs[0]
+        assert mongo_sv['pos_sum'] == formated_variant['pos'] + formated_variant_['pos']
+        # And two identity documents
+        mongo_identities = list(db.identity.find())
+        assert len(mongo_identities) == 2
+
+        # WHEN deleting the variant from the first case
+        mongo_adapter.delete_structural_variant(formated_variant)
+
+        # THEN the SV document should have the pos_sum equal to the pos of the
+        # SV from the second case
+        mongo_svs = list(db.structural_variant.find())
+        assert len(mongo_svs) == 1
+        mongo_sv = mongo_svs[0]
+        assert mongo_sv['pos_sum'] == formated_variant_['pos']
+        # And one identity documents
+        mongo_identities = list(db.identity.find())
+        assert len(mongo_identities) == 1

--- a/tests/plugins/mongo/test_variant_operations.py
+++ b/tests/plugins/mongo/test_variant_operations.py
@@ -247,3 +247,55 @@ class TestRemoveSV:
         # And one identity documents
         mongo_identities = list(db.identity.find())
         assert len(mongo_identities) == 1
+
+class TestHelperMethods:
+
+    def test_update_sv_metrics(self, mongo_adapter):
+        # GIVEN a mongo adapter
+
+        # WHEN cluster_len > 10000
+        cluster_len, interval_size = mongo_adapter._update_sv_metrics(sv_type='INV',
+                                                                      pos_mean=10000,
+                                                                      end_mean=30000,
+                                                                      max_window=3000)
+        # THEN interval_size should be the cluster_len divided by 10
+        assert cluster_len == 20000
+        assert interval_size == round(20000/10, -2)
+
+        # WHEN cluster_len <10000
+        cluster_len, interval_size = mongo_adapter._update_sv_metrics(sv_type='DUP',
+                                                                      pos_mean=10000,
+                                                                      end_mean=15000,
+                                                                      max_window=3000)
+
+        # THEN interval_size should be cluster_len divided by 5
+        assert cluster_len == 5000
+        assert interval_size == round(5000/5, -2)
+
+        # WHEN interval_size < 1000
+        cluster_len, interval_size = mongo_adapter._update_sv_metrics(sv_type='DEL',
+                                                                      pos_mean=10000,
+                                                                      end_mean=10500,
+                                                                      max_window=3000)
+
+        # THEN interval_size should be cluster_len divided by 2
+        assert cluster_len == 500
+        assert interval_size == round(500/2, -2)
+
+        # WHEN interval size is > max_window
+        cluster_len, interval_size = mongo_adapter._update_sv_metrics(sv_type='INV',
+                                                                      pos_mean=100000,
+                                                                      end_mean=200000,
+                                                                      max_window=3000)
+        # THEN interval size should be set to max_window
+        assert cluster_len == 100000
+        assert interval_size == 3000
+
+        # WHEN sv_type == BND
+        cluster_len, interval_size = mongo_adapter._update_sv_metrics(sv_type='BND',
+                                                                      pos_mean=1000,
+                                                                      end_mean=2000,
+                                                                      max_window=3000)
+        # THEN cluster_len should be 10e10 and interval_size 2*max window
+        assert cluster_len == 10e10
+        assert interval_size == 2*3000

--- a/tests/utils/test_delete.py
+++ b/tests/utils/test_delete.py
@@ -44,6 +44,31 @@ def test_delete_case_and_variants(vcf_path, ped_path, real_mongo_adapter, case_i
 
     assert mongo_case == None
 
-    mongo_variant = db.case.find_one()
+    mongo_variant = db.variant.find_one()
 
     assert mongo_variant == None
+
+
+def test_delete_structural_variants(vcf_path, ped_path, real_mongo_adapter, case_id, sv_case_obj):
+
+    # GIVEN a mongo adapter with an inserted case with SVs
+    mongo_adapter = real_mongo_adapter
+    db = mongo_adapter.db
+
+    load_database(
+        adapter=mongo_adapter,
+        variant_file=sv_case_obj['vcf_path'],
+        family_file=ped_path,
+        family_type='ped',
+        sv_file=sv_case_obj['vcf_sv_path']
+    )
+
+    mongo_svs = db.structural_variant.find()
+    assert len(list(mongo_svs)) == 19
+
+    # WHEN deleteing the case
+    delete(adapter=mongo_adapter, case_obj=sv_case_obj)
+
+    # All structural variants should be deleted.
+    mongo_svs = db.structural_variant.find()
+    assert len(list(mongo_svs)) == 0

--- a/tests/utils/test_delete_variant.py
+++ b/tests/utils/test_delete_variant.py
@@ -3,23 +3,23 @@ from loqusdb.utils.load import load_variants
 from loqusdb.build_models.variant import get_variant_id
 
 
-def test_delete_variants(mongo_adapter, het_variant, case_obj):
+def test_delete_variants(real_mongo_adapter, het_variant, case_obj):
     ## GIVEN a database with one variant
-    db = mongo_adapter.db
+    db = real_mongo_adapter.db
     case_id = case_obj['case_id']
-    
+
     db.variant.insert_one({
         '_id': get_variant_id(het_variant),
         'families': [case_id],
         'observations': 1,
     })
-    
+
     mongo_variant = db.variant.find_one()
     assert mongo_variant['families'] == [case_id]
 
     ## WHEN deleting the variant
     delete_variants(
-        adapter=mongo_adapter,
+        adapter=real_mongo_adapter,
         vcf_obj=[het_variant],
         case_obj=case_obj
     )
@@ -29,11 +29,11 @@ def test_delete_variants(mongo_adapter, het_variant, case_obj):
     ## THEN assert that the variant was not found
     assert mongo_variant == None
 
-def test_delete_variant(mongo_adapter, het_variant, case_obj):
+def test_delete_variant(real_mongo_adapter, het_variant, case_obj):
     ## GIVEN a database with one variant that is observed twice
-    db = mongo_adapter.db
+    db = real_mongo_adapter.db
     case_id = case_obj['case_id']
-    
+
     db.variant.insert_one({
         '_id': get_variant_id(het_variant),
         'families': [case_id, '2'],
@@ -45,7 +45,7 @@ def test_delete_variant(mongo_adapter, het_variant, case_obj):
 
     ## WHEN deleting the variant for one case
     delete_variants(
-        adapter=mongo_adapter,
+        adapter=real_mongo_adapter,
         vcf_obj=[het_variant],
         case_obj=case_obj,
         case_id='2',


### PR DESCRIPTION
Add function so that SVs are also deleted together with case
Add functionality to delete/update variants in bulks, which should be
more time efficient. Currently for each variant to be deleted in a case, this single variant is first queried and then deleted/updated. This means a lot of operations on the database. 