### PR TITLE
Modifying SV counting

### DIFF
--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -133,7 +133,8 @@ def get_coords(variant):
     if (sv_len == 0 and alt != '<INS>'):
         sv_len = len(alt)
 
-    if (pos == end) and (sv_len > 0) and sv_len != float('inf'):
+    # if (pos == end) and (sv_len > 0) and sv_len != float('inf'):
+    if (end != pos + sv_len) and (sv_len > 0) and sv_len != float('inf'):
         end = pos + sv_len
 
     position = Position(chrom, pos)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,6 +229,25 @@ def sv_case_obj(request, case_lines, sv_vcf_obj, sv_vcf_path):
     return _case_obj
 
 @pytest.fixture(scope='function')
+def sv_case_obj2(request, case_lines, sv_vcf_obj, sv_vcf_path):
+    """Return a case obj (for testing clustering and querying of sv_case_obj)"""
+    family_parser = FamilyParser(case_lines, family_type='ped')
+    families = list(family_parser.families.keys())
+    family = family_parser.families[families[0]]
+    vcf_individuals = sv_vcf_obj.samples
+    nr_variants = 0
+    for nr_variants,variant in enumerate(sv_vcf_obj,1):
+        pass
+    _case_obj = build_case(
+        case=family,
+        case_id="secondary",
+        sv_individuals=vcf_individuals,
+        vcf_sv_path=sv_vcf_path,
+        nr_sv_variants=nr_variants,
+        )
+    return _case_obj
+
+@pytest.fixture(scope='function')
 def complete_case_obj(request, case_obj, sv_case_obj):
     """Return a case obj with both sv and snv information"""
     _case_obj = update_case(case_obj, sv_case_obj)
@@ -351,11 +370,11 @@ def del_variant(request):
         ref='G',
         alt='<DEL>',
         pos=1285001,
-        end=1287000,
+        end=1287001,
         var_type='sv',
         info_dict={
-            'END': 1287000,
-            'SVLEN': -20000,
+            'END': 1287001,
+            'SVLEN': -2000,
             'SVTYPE': 'DEL'
         }
     )
@@ -390,6 +409,40 @@ def insertion_variant(request):
         info_dict={
             'END': 3177306,
             'SVLEN': None,
+            'SVTYPE': 'INS'
+        }
+    )
+    return variant_object
+
+@pytest.fixture(scope='function')
+def insertion_variant_inaccurate(request):
+    variant_object = CyvcfVariant(
+        chrom='1',
+        ref='N',
+        alt='<INS>',
+        pos=3177306,
+        end=3177307,
+        var_type='sv',
+        info_dict={
+            'END': 3177307,
+            'SVLEN': 100,
+            'SVTYPE': 'INS'
+        }
+    )
+    return variant_object
+
+@pytest.fixture(scope='function')
+def insertion_variant_accurate(request):
+    variant_object = CyvcfVariant(
+        chrom='1',
+        ref='A',
+        alt='AGGGACGGGGGTTCTGAGATAAGCAAGCCCCCACCAGGTGAGACCGGCGGAGCTGTGGCCACCGAGGTCCCGGGAGCTGGTGCTGGGACGGGGGTTCTGAGATAAGCAAGCCCCC',
+        pos=3177315,
+        end=3177315,
+        var_type='sv',
+        info_dict={
+            'END': 3177315,
+            'SVLEN': 115,
             'SVTYPE': 'INS'
         }
     )

--- a/tests/plugins/mongo/test_get_sv.py
+++ b/tests/plugins/mongo/test_get_sv.py
@@ -1,4 +1,5 @@
 from loqusdb.build_models.variant import build_variant
+from loqusdb.plugins.mongo.structural_variant import HARD_LIMIT_ACCURACY
 
 def test_get_insertion(small_insert_variant, mongo_adapter, case_obj):
     adapter = mongo_adapter
@@ -31,3 +32,54 @@ def test_get_translocation(translocation_variant, mongo_adapter, case_obj):
     adapter.add_structural_variant(formated_variant)
     for variant_obj in adapter.db.structural_variant.find():
         assert variant_obj
+
+def test_count_borderline_cases(small_insert_variant, insertion_variant_inaccurate, insertion_variant_accurate, mongo_adapter, sv_case_obj, sv_case_obj2):
+    adapter = mongo_adapter
+    ## GIVEN a mongo adapter with a small insertion (listed twice in VCF), one insertion larger than 100bp (inaccurate, i.e. not sequence resolved)
+    ## AND and one insertion larger than 100p from another family (similar to the larger variant from first family, but accurate, i.e. sequence resolved)
+    variant_smaller = small_insert_variant
+    variant_larger_inaccurate = insertion_variant_inaccurate
+    variant_larger_accurate = insertion_variant_accurate
+    sv_case_id = sv_case_obj['case_id']
+    sv_case_id2 = sv_case_obj2['case_id']
+    
+    formated_variant_smaller = build_variant(
+        variant=variant_smaller,
+        case_obj=sv_case_obj,
+        case_id=sv_case_id
+    )
+    formated_variant_smaller_duplicate = build_variant(
+        variant=variant_smaller,
+        case_obj=sv_case_obj,
+        case_id=sv_case_id
+    )
+    formated_variant_larger_inaccurate = build_variant(
+        variant=variant_larger_inaccurate,
+        case_obj=sv_case_obj,
+        case_id=sv_case_id
+    )
+    formated_variant_larger_accurate = build_variant(
+        variant=variant_larger_accurate,
+        case_obj=sv_case_obj2,
+        case_id=sv_case_id2
+    )
+    
+    adapter.add_case(sv_case_obj)
+    adapter.add_case(sv_case_obj2)
+    adapter.add_structural_variant(formated_variant_larger_accurate)
+    adapter.add_structural_variant(formated_variant_larger_inaccurate)
+    adapter.add_structural_variant(formated_variant_smaller)
+    adapter.add_structural_variant(formated_variant_smaller_duplicate)
+
+    # Test is written for the case that variants less than 100bp are considered accurate
+    assert HARD_LIMIT_ACCURACY == 100
+
+    for variant in [formated_variant_larger_inaccurate, formated_variant_smaller, formated_variant_larger_accurate, formated_variant_smaller_duplicate]:
+        var = adapter.get_structural_variant(variant)
+        # Variants larger than 100bp are not clustered together with variants smaller than 100bp
+        if var["length"] >= 100:
+            # Variants from different families are added
+            assert var["observations"] == 2
+        else:
+            # Duplicate is not added to cluster
+            assert var["observations"] == 1

--- a/tests/vcf_tools/test_format_sv_variant.py
+++ b/tests/vcf_tools/test_format_sv_variant.py
@@ -79,6 +79,40 @@ def test_format_insertion(insertion_variant, case_obj):
     assert formated_variant['ref'] == variant.REF
     assert formated_variant['alt'] == variant.ALT[0]
     assert formated_variant['sv_type'] == 'INS'
+
+def test_format_insertion_larger(insertion_variant_inaccurate, insertion_variant_accurate, case_obj):
+    ## GIVEN variants large than 100bp (inaccurate is not sequence resolved, accurate is sequence resolved)
+    ## Inaccurate:
+    variant = insertion_variant_inaccurate
+    case_id = case_obj['case_id']
+    ## WHEN parsing the variant
+    formated_variant = build_variant(
+        variant=variant,
+        case_obj=case_obj,
+        case_id=case_id
+        )
+    
+    ## THEN assert the sv is parsed correct
+    assert formated_variant['chrom'] == variant.CHROM
+    assert formated_variant['end_chrom'] == variant.CHROM
+    assert formated_variant['pos'] == variant.POS
+    assert formated_variant['end'] == variant.POS+variant.INFO['SVLEN']
+    assert formated_variant['sv_len'] == variant.INFO['SVLEN']
+    assert formated_variant['ref'] == variant.REF
+    assert formated_variant['alt'] == variant.ALT[0]
+    assert formated_variant['sv_type'] == 'INS'
+
+    ## Accurate
+    variant_accurate = insertion_variant_accurate
+    ## WHEN parsing the variant
+    formated_variant_accurate = build_variant(
+        variant=variant_accurate,
+        case_obj=case_obj,
+        case_id=case_id
+        )
+    ## THEN assert the sv is parsed correct
+    assert formated_variant_accurate['end'] == variant_accurate.POS+variant_accurate.INFO['SVLEN']
+    assert formated_variant_accurate['sv_len'] == variant_accurate.INFO['SVLEN']
     
 def test_format_dup_tandem(duptandem_variant, case_obj):
     ## GIVEN a small insertion (This means that the insertion is included in ALT field)


### PR DESCRIPTION
Hi @moonso, thank you for publishing your counting database. We hope to be able to use it for an internal database of our variants, and appreciate that you already have tested it in a clinical environment.

I have proposed some changes to how loqusdb treats structural variants:
* The normal way to denote INS is to set POS=END. In some cases this is not the case: If the length of REF>1 (Manta) or if for some reason the caller has chosen the to set POS=END+1 (DELLY). In these cases, the INS gets wrong length in loqusdb (commit [870880c](https://github.com/moonso/loqusdb/commit/870880ccdbdadc474da73dd1460545d9871a7d17))
* In loqusdb variants with length less than 100bp require an exact match to be counted, above 100bp various degrees of mismatch are allowed. In the case that several variants larger than 100bp have been clustered/counted, adding a variant smaller than 100bp may in some rare cases transform the cluster into an accurate variant which does not match any observed variant. One consequence of this behaviour is that the variant count depends on the order in which variants were inserted into the database. I have forced the accurate and non-accurate variants to be kept separate when creating the database. I have also removed a rounding function, which would round cluster size upwards or downwards depending on the order of insertion into the database. I also forced the length of a translocation to be an integer. Commit [62fca1d ](https://github.com/moonso/loqusdb/commit/62fca1d4bf7614bda3841cd1876ac39fa02d70b2)
* I have made tests for the above changes. And [fixed a test that did not work](https://github.com/moonso/loqusdb/compare/master...ousamg:amg-1947-loqusdb?expand=1#diff-484462fced51d1a06b1d93b4a44dd535) (`SVLEN=20000` -> `SVLEN=2000`, line 358)