### PR TITLE
Fix variant sorting when exporting

### DIFF
--- a/loqusdb/plugins/mongo/variant.py
+++ b/loqusdb/plugins/mongo/variant.py
@@ -174,7 +174,7 @@ class VariantMixin(BaseVariantMixin, SVMixin):
             query['start'] = {'$lte': end}
             query['end'] = {'$gte': start}
         LOG.info("Find all variants {}".format(query))
-        return self.db.variant.find(query).sort([('start', ASCENDING)])
+        return self.db.variant.find(query).sort([('pos', ASCENDING)])
 
     def delete_variant(self, variant):
         """Delete observation in database


### PR DESCRIPTION
Got this message when trying ```loqusdb export```on SNVs

```
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding info line to vcf: ##INFO=<ID=Obs,Number=1,Type=Integer,Description="The number of observations for the variant">
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding info line to vcf: ##INFO=<ID=Hom,Number=1,Type=Integer,Description="The number of observed homozygotes">
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding info line to vcf: ##INFO=<ID=Hem,Number=1,Type=Integer,Description="The number of observed hemizygotes">
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=1,length=249240608>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=2,length=243189191>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=3,length=197961601>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=4,length=191044275>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=5,length=180905120>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=6,length=171053661>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=7,length=159128661>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=8,length=146303742>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=9,length=141153153>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=10,length=135524744>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=11,length=134946513>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=12,length=133841678>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=13,length=115109853>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=14,length=107289457>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=15,length=102521386>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=16,length=90294733>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=17,length=81195191>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=18,length=78017152>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=19,length=59118988>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=20,length=62965514>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=21,length=48119891>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=22,length=51244516>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=X,length=155260468>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=Y,length=59034001>
2019-10-24 13:21:06 hasta.scilifelab.se vcftoolbox.header_parser[333720] INFO Adding contig line to vcf: ##contig=<ID=MT,length=16567>
2019-10-24 13:21:06 hasta.scilifelab.se loqusdb.commands.export[333720] INFO Collecting all SNV variants
2019-10-24 13:21:06 hasta.scilifelab.se loqusdb.plugins.mongo.variant[333720] INFO Find all variants {'chrom': '1'}
2019-10-24 13:21:26 hasta.scilifelab.se loqusdb.commands.export[333720] INFO 6987348 variants found
Traceback (most recent call last):
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/bin/loqusdb", line 10, in <module>
    sys.exit(base_command())
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/loqusdb/commands/export.py", line 81, in export
    for variant in variants:
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/pymongo/cursor.py", line 1189, in next
    if len(self.__data) or self._refresh():
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/pymongo/cursor.py", line 1104, in _refresh
    self.__send_message(q)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/pymongo/cursor.py", line 982, in __send_message
    helpers._check_command_response(first)
  File "/home/proj/bin/conda/envs/P_loqusdb-v2/lib/python3.7/site-packages/pymongo/helpers.py", line 155, in _check_command_response
    raise OperationFailure(msg % errmsg, code, response)
pymongo.errors.OperationFailure: errmsg: "Sort operation used more than the maximum 33554432 bytes of RAM. Add an index, or specify a smaller limit."
```

I think I've found the problem, although I'm not sure. 