### PR TITLE
Updates coordinates index. Fix #71

### DIFF
--- a/loqusdb/__init__.py
+++ b/loqusdb/__init__.py
@@ -11,7 +11,7 @@ INDEXES = {
     'variant' : [
         IndexModel([
         ('chrom', ASCENDING),
-        ('pos', ASCENDING),
+        ('start', ASCENDING),
         ('end', ASCENDING),
         ], name="coordinates"),
         


### PR DESCRIPTION
This PR updates the "coordinates" index to use 'start' instead of 'pos' when fetching variants.

