### PR TITLE
Add observation frequency to every variant of the exported VCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
+### Added
+- Option to add observation frequencies to exported VCF (--freq)
+
 ## [2.5]
 
 ### Added

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -53,6 +53,7 @@ def export(ctx, outfile, variant_type):
     head = HeaderParser()
     head.add_fileformat("VCFv4.3")
     head.add_meta_line("NrCases", nr_cases)
+    head.add_info("Frq", '1', 'Float', "Observation frequency of the variant (not allele frequency)")
     head.add_info("Obs", '1', 'Integer', "The number of observations for the variant")
     head.add_info("Hom", '1', 'Integer', "The number of observed homozygotes")
     head.add_info("Hem", '1', 'Integer', "The number of observed hemizygotes")
@@ -79,7 +80,7 @@ def export(ctx, outfile, variant_type):
             variants = adapter.get_sv_variants(chromosome=chrom)
         LOG.info("{} variants found".format(variants.count()))
         for variant in variants:
-            variant_line = format_variant(variant, variant_type=variant_type)
+            variant_line = format_variant(variant, variant_type=variant_type, nr_cases=nr_cases)
             # chrom = variant['chrom']
             # pos = variant['start']
             # ref = variant['ref']

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -24,8 +24,12 @@ LOG = logging.getLogger(__name__)
     show_default=True,
     help="If svs or snvs should be exported"
 )
+@click.option('-f','--freq',
+    is_flag=True,
+    help="Include observation frequencies in the exported VCF"
+)
 @click.pass_context
-def export(ctx, outfile, variant_type):
+def export(ctx, outfile, variant_type, freq):
     """Export the variants of a loqus db
         
         The variants are exported to a vcf file
@@ -53,7 +57,8 @@ def export(ctx, outfile, variant_type):
     head = HeaderParser()
     head.add_fileformat("VCFv4.3")
     head.add_meta_line("NrCases", nr_cases)
-    head.add_info("Frq", '1', 'Float', "Observation frequency of the variant (not allele frequency)")
+    if freq:
+        head.add_info("Frq", '1', 'Float', "Observation frequency of the variant (not allele frequency)")
     head.add_info("Obs", '1', 'Integer', "The number of observations for the variant")
     head.add_info("Hom", '1', 'Integer', "The number of observed homozygotes")
     head.add_info("Hem", '1', 'Integer', "The number of observed hemizygotes")
@@ -80,7 +85,7 @@ def export(ctx, outfile, variant_type):
             variants = adapter.get_sv_variants(chromosome=chrom)
         LOG.info("{} variants found".format(variants.count()))
         for variant in variants:
-            variant_line = format_variant(variant, variant_type=variant_type, nr_cases=nr_cases)
+            variant_line = format_variant(variant, variant_type=variant_type, nr_cases=nr_cases, add_freq=freq)
             # chrom = variant['chrom']
             # pos = variant['start']
             # ref = variant['ref']

--- a/loqusdb/utils/variant.py
+++ b/loqusdb/utils/variant.py
@@ -3,12 +3,13 @@ import logging
 from pprint import pprint as pp
 LOG = logging.getLogger(__name__)
 
-def format_info(variant, variant_type='snv'):
+def format_info(variant, variant_type='snv', nr_cases=None):
     """Format the info field for SNV variants
     
     Args:
         variant(dict)
         variant_type(str): snv or sv
+        nr_cases(int)
     
     Returns:
         vcf_info(str): A VCF formated info field
@@ -19,12 +20,15 @@ def format_info(variant, variant_type='snv'):
     homozygotes = variant.get('homozygote')
     hemizygotes = variant.get('hemizygote')
 
-    
     vcf_info = f"Obs={observations}"
     if homozygotes:
         vcf_info += f";Hom={homozygotes}"
     if hemizygotes:
         vcf_info += f";Hem={hemizygotes}"
+
+    if nr_cases and nr_cases > 0:
+        frequency = observations / nr_cases
+        vcf_info += f";Frq={frequency:.5f}"
 
     # This is SV specific
     if variant_type == 'sv':
@@ -34,12 +38,13 @@ def format_info(variant, variant_type='snv'):
 
     return vcf_info
 
-def format_variant(variant, variant_type='snv'):
+def format_variant(variant, variant_type='snv', nr_cases=None):
     """Convert variant information to a VCF formated string
     
     Args:
         variant(dict)
         variant_type(str)
+        nr_cases(int)
     
     Returns:
         vcf_variant(str)
@@ -57,7 +62,7 @@ def format_variant(variant, variant_type='snv'):
 
     info = None
     
-    info = format_info(variant, variant_type=variant_type)
+    info = format_info(variant, variant_type=variant_type, nr_cases=nr_cases)
 
     variant_line = f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t.\t.\t{info}"
     

--- a/loqusdb/utils/variant.py
+++ b/loqusdb/utils/variant.py
@@ -3,7 +3,7 @@ import logging
 from pprint import pprint as pp
 LOG = logging.getLogger(__name__)
 
-def format_info(variant, variant_type='snv', nr_cases=None):
+def format_info(variant, variant_type='snv', nr_cases=None, add_freq=False):
     """Format the info field for SNV variants
     
     Args:
@@ -26,7 +26,7 @@ def format_info(variant, variant_type='snv', nr_cases=None):
     if hemizygotes:
         vcf_info += f";Hem={hemizygotes}"
 
-    if nr_cases and nr_cases > 0:
+    if add_freq and nr_cases and nr_cases > 0:
         frequency = observations / nr_cases
         vcf_info += f";Frq={frequency:.5f}"
 
@@ -38,7 +38,7 @@ def format_info(variant, variant_type='snv', nr_cases=None):
 
     return vcf_info
 
-def format_variant(variant, variant_type='snv', nr_cases=None):
+def format_variant(variant, variant_type='snv', nr_cases=None, add_freq=False):
     """Convert variant information to a VCF formated string
     
     Args:
@@ -62,7 +62,7 @@ def format_variant(variant, variant_type='snv', nr_cases=None):
 
     info = None
     
-    info = format_info(variant, variant_type=variant_type, nr_cases=nr_cases)
+    info = format_info(variant, variant_type=variant_type, nr_cases=nr_cases, add_freq=add_freq)
 
     variant_line = f"{chrom}\t{pos}\t.\t{ref}\t{alt}\t.\t.\t{info}"
     


### PR DESCRIPTION
This PR adds an observation frequency (n_obs/n_cases) to every line of the exported VCF. It is NOT an allele frequency.

```
1       52506   .       A       C       .       .       Obs=17;Hom=2;Frq=0.09290
1       53138   .       TAA     T       .       .       Obs=17;Hom=4;Frq=0.09290
1       54366   .       A       G       .       .       Obs=1;Frq=0.00546
```

I understand that there is probably a reason that this hasn't beed added already? I've added this because it feels strange to use observations counts in the rank model, since it changes meaning over time... 

I could add a commad line option to enable this, if you think this should be optional.
