### PR TITLE
Improve tests and extend connectivity (database restore) to support a Mongo replica set

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6]
-        mongodb-version: ["3.6"]
+        mongodb-version: ["3.2", "4.4", "5.0"]
 
     steps:
     # Check out Scout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [unreleased]
 ### Added
 ### Changed
+- GitHub actions run tests using MongoDB versions 3.2, 4.4 and 5.0
 ### Fixed
+- Restore command accepts custom database name
+- Restore command uses either database URI or host:port params
 
 ## [2.5.2]
 

--- a/loqusdb/commands/cli.py
+++ b/loqusdb/commands/cli.py
@@ -109,10 +109,11 @@ def cli(ctx, database, username, password, authdb, port, host, uri, verbose, con
 
     ctx.obj = {}
     ctx.obj['db'] = database
-    ctx.obj['user'] = username
-    ctx.obj['password'] = password
-    ctx.obj['port'] = port
-    ctx.obj['host'] = host
+    if uri:
+        ctx.obj['uri'] = uri
+    else:
+        ctx.obj['port'] = port
+        ctx.obj['host'] = host
     ctx.obj['adapter'] = adapter
     ctx.obj['version'] = __version__
     ctx.obj['genome_build'] = genome_build

--- a/loqusdb/commands/restore.py
+++ b/loqusdb/commands/restore.py
@@ -13,23 +13,27 @@ from loqusdb.resources import background_path
 LOG = logging.getLogger(__name__)
 
 @base_command.command('restore', short_help="Restore database from dump")
-@click.option('-f' ,'--filename', 
+@click.option('-f' ,'--filename',
                 help='If custom named file is to be used',
                 type=click.Path(exists=True),
 )
 @click.pass_context
 def restore(ctx, filename):
     """Restore the database from a zipped file.
-    
+
     Default is to restore from db dump in loqusdb/resources/
     """
     filename = filename or background_path
     if not os.path.isfile(filename):
         LOG.warning("File {} does not exist. Please point to a valid file".format(filename))
         ctx.abort()
-    
-    call = ['mongorestore', '--gzip', '--db', 'loqusdb', '--archive={}'.format(filename)]
-    
+
+    call = ['mongorestore', '--gzip', '--archive={}'.format(filename), '--db', ctx.obj.get('db')]
+      if ctx.obj.get('uri'):
+          call.append(f"--uri={ctx.obj['uri']}")
+      else: # Use host and port
+          call.append(f"--host={ctx.obj['host']}:{ctx.obj['port']}")
+
     LOG.info('Restoring database from %s', filename)
     start_time = datetime.now()
     try:
@@ -37,8 +41,6 @@ def restore(ctx, filename):
     except subprocess.CalledProcessError as err:
         LOG.warning(err)
         ctx.abort()
-    
+
     LOG.info('Database restored succesfully')
     LOG.info('Time to restore database: {0}'.format(datetime.now()-start_time))
-    
-    

--- a/loqusdb/commands/restore.py
+++ b/loqusdb/commands/restore.py
@@ -29,10 +29,10 @@ def restore(ctx, filename):
         ctx.abort()
 
     call = ['mongorestore', '--gzip', '--archive={}'.format(filename), '--db', ctx.obj.get('db')]
-      if ctx.obj.get('uri'):
-          call.append(f"--uri={ctx.obj['uri']}")
-      else: # Use host and port
-          call.append(f"--host={ctx.obj['host']}:{ctx.obj['port']}")
+    if ctx.obj.get('uri'): # if db URI is available use it
+        call.append(f"--uri={ctx.obj['uri']}")
+    else: # Otherwise use host and port
+        call.append(f"--host={ctx.obj['host']}:{ctx.obj['port']}")
 
     LOG.info('Restoring database from %s', filename)
     start_time = datetime.now()


### PR DESCRIPTION
LoqusDB should already be able to support connections to a replica set given that the config file contains `uri` and `db_name` params.

### This PR adds | fixes:
- Improves tests by running them on 3 different versions of MongoDB (3.2, 4.4 and 5.0)
- Modifies the cli `restore` function to accept custom database names
- Modifies the same function to connect to MongoDB via a URI or HOST:PORT

**How to prepare for test**:
- [ ] Install the repo and switch to this branch
- [ ] Start a dockerized MongoDB replica set using the following command: `docker run --name mongo-replica-set -d -p 27011:27011 -p 27012:27012 -p 27013:27013 northwestwitch/mongo4.4-replica-set`

## How to test by providing db URI when running cli commands
- [x] Connect to database and load demo data into it using the following command:
```
loqusdb -db loqusdb --uri mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/?replicaSet=rs0 restore --filename loqusdb/resources/loqusdb.20181005.gz
```
- [x] Run a test query:
```
loqusdb -db loqusdb --uri mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/?replicaSet=rs0 variants --sv-type INS
```

## How to test by providing a config file
1. Remove the existing mongodb database (you could stop and restart the docker replica set)
2. Create a yaml config file containing the following lines:
```
uri: mongodb://127.0.0.1:27011,127.0.0.1:27012,127.0.0.1:27013/?replicaSet=rs0
db_name: loqusdb
```
- [x] run the same commands as above using the` loqusdb --config` option instead of providing uri and db name when running the cli

### Expected outcome:
- [x] The above tests should work

### Review:
- [x] Code approved by DN
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
