### PR TITLE
Revert contig name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Added
+- Script to correct contig name
 ### Changed
 - GitHub actions run tests using MongoDB versions 3.2, 4.4 and 5.0
 ### Fixed

--- a/scripts/revert_contig_name_trim.py
+++ b/scripts/revert_contig_name_trim.py
@@ -1,0 +1,40 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import re
+
+import click
+
+from pymongo import MongoClient
+
+@click.command()
+@click.option("--db-uri", required=True, help="mongodb://user:password@db_url:db_port")
+@click.option("--db-name", required=True, help="db name")
+@click.option("--live", help="Use this flag to arm the script", is_flag=True, default=False)
+def revert_contig_name_trim(db_uri, db_name, live=False):
+    try:
+        client = MongoClient(db_uri)
+        db = client[db_name]
+        # test connection
+        click.echo("database connection info:{}".format(db))
+        old_GL_pattern = re.compile("^L00")
+
+        variants = list(db.structural_variant.find(
+            {"end_chrom": old_GL_pattern}))
+
+        click.echo(f"found: {len(variants)} trimmed end_chrom")
+
+        for variant in variants:
+            old_end = variant["end_chrom"]
+            new_end = "G" + old_end
+            variant["end_chrom"] = new_end
+            if live:
+                db.structural_variant.find_one_and_update(
+                    {"_id": variant["_id"]}, {"end_chrom": new_end}
+                )
+            click.echo(f"old end_chrom: {old_end} -> new end_chrom {new_end}")
+
+    except Exception as err:
+        click.echo("Error {}".format(err))
+
+if __name__ == "__main__":
+    revert_contig_name_trim()


### PR DESCRIPTION
### This PR adds | fixes:
- 

**How to prepare for test**:
- [ ] `ssh` to ...
- [ ] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
```
(scout39n) k1315C02VR0WRHTDH:scripts dannil$ python revert_contig_name_trim.py --db-uri mongodb://localhost:27030 --db-name loqusdb-rd
database connection info:Database(MongoClient(host=['localhost:27030'], document_class=dict, tz_aware=False, connect=True), 'loqusdb-rd')
found: 1228 trimmed end_chrom
old end_chrom: L000232.1 -> new end_chrom GL000232.1
old end_chrom: L000234.1 -> new end_chrom GL000234.1
...
```
### Expected outcome:
- [ ] produces a list of edits
- [ ] if run with `--live`, updates the database

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
