### PR TITLE
Fix #117 - add a flag to allow QUAL filter instead of GQ

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
  build-n-publish:
   name: Build and publish Python distribution to PyPI
-  runs-on: ubuntu-18.04
+  runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
      uses: actions/checkout@v3

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,10 +12,10 @@ jobs:
   runs-on: ubuntu-18.04
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v2
+     uses: actions/checkout@v3
 
    - name: Set up Python 3.9
-     uses: actions/setup-python@v2
+     uses: actions/setup-python@v4
      with:
       python-version: 3.9
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Production Dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e . 
 
     - name: Dev Dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     # Check out Scout code
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     # Set up python
     - name: Set up Python ${{ matrix.python-version}}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version}}
 

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -139,7 +139,7 @@ def get_coords(variant):
     return coordinates
 
 
-def build_variant(variant, case_obj, case_id=None, gq_threshold=None, genome_build=None):
+def build_variant(variant, case_obj, case_id=None, gq_threshold=None, gq_qual=False, genome_build=None):
     """Return a Variant object
 
     Take a cyvcf2 formated variant line and return a models.Variant.
@@ -188,7 +188,13 @@ def build_variant(variant, case_obj, case_id=None, gq_threshold=None, genome_bui
             ind_id = ind_obj["ind_id"]
             # Get the index position for the individual in the VCF
             ind_pos = ind_obj["ind_index"]
-            gq = int(variant.gt_quals[ind_pos])
+
+            if gq_qual:
+                gq = int(variant.QUAL)
+
+            if not gq_qual:
+                gq = int(variant.gt_quals[ind_pos])
+
             if gq_threshold and gq < gq_threshold:
                 continue
 

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -55,6 +55,7 @@ def validate_profile_threshold(ctx, param, value):
 )
 @click.option("--ensure-index", is_flag=True, help="Make sure that the indexes are in place")
 @click.option("--gq-threshold", default=20, show_default=True, help="Threshold to consider variant")
+@click.option("--qual-gq", is_flag=True, default=False, show_default=True, help="Use QUAL tag instead of GQ value for quality filter")
 @click.option(
     "--max-window",
     "-m",
@@ -96,6 +97,7 @@ def load(
     check_profile,
     hard_threshold,
     soft_threshold,
+    qual_gq
 ):
     """Load the variants of a case
 
@@ -137,6 +139,7 @@ def load(
             skip_case_id=skip_case_id,
             case_id=case_id,
             gq_threshold=gq_threshold,
+            qual_gq=qual_gq,
             max_window=max_window,
             profile_file=variant_profile_path,
             hard_threshold=hard_threshold,

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -32,6 +32,7 @@ def load_database(
     family_type="ped",
     skip_case_id=False,
     gq_threshold=None,
+    qual_gq=False,
     case_id=None,
     max_window=3000,
     profile_file=None,
@@ -49,6 +50,7 @@ def load_database(
           family_type(str): Format of family file
           skip_case_id(bool): If no case information should be added to variants
           gq_threshold(int): If only quality variants should be considered
+          qual_gq(bool): Use QUAL field instead of GQ format tag to gate quality
           case_id(str): If different case id than the one in family file should be used
           max_window(int): Specify the max size for sv windows
           check_profile(bool): Does profile check if True
@@ -92,7 +94,7 @@ def load_database(
         # Get a cyvcf2.VCF object
         vcf = get_vcf(_vcf_file)
 
-        if gq_threshold and not vcf.contains("GQ"):
+        if gq_threshold and not vcf.contains("GQ") and not qual_gq:
             LOG.warning("Set gq-threshold to 0 or add info to vcf {0}".format(_vcf_file))
             raise SyntaxError("GQ is not defined in vcf header")
 
@@ -144,6 +146,7 @@ def load_database(
                 case_obj=case_obj,
                 skip_case_id=skip_case_id,
                 gq_threshold=gq_threshold,
+                qual_gq=qual_gq,
                 max_window=max_window,
                 variant_type=variant_type,
                 genome_build=genome_build,
@@ -190,6 +193,7 @@ def load_variants(
     case_obj,
     skip_case_id=False,
     gq_threshold=None,
+    qual_gq=False,
     max_window=3000,
     variant_type="snv",
     genome_build=None,
@@ -222,7 +226,7 @@ def load_variants(
     with click.progressbar(vcf_obj, label="Inserting variants", length=nr_variants) as bar:
 
         variants = (
-            build_variant(variant, case_obj, case_id, gq_threshold, genome_build=genome_build)
+            build_variant(variant, case_obj, case_id, gq_threshold, qual_gq, genome_build=genome_build)
             for variant in bar
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ numpy==1.21.4
 coloredlogs==14.0
 pyyaml==5.4.0
 vcftoolbox==1.5
-pip==21.3.1
 setuptools==59.2.0
 mongo_adapter>=0.3.3
 ped_parser

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,6 @@
 import io
 import os
 
-from pip._internal.network.session import PipSession
-from pip._internal.req import parse_requirements
 from setuptools import find_packages, setup
 
 # Package meta-data.
@@ -23,11 +21,8 @@ AUTHOR = "Måns Magnusson"
 REQUIRES_PYTHON = ">=3.7.0"
 VERSION = "2.6.10"
 
-requirements = [
-    requirement.requirement
-    for requirement in parse_requirements(filename="./requirements.txt", session=PipSession())
-]
-
+with open('requirements.txt') as f:
+    install_requires = f.read().strip().split('\n')
 
 # The rest you shouldn't have to touch too much :)
 # ------------------------------------------------
@@ -68,7 +63,7 @@ setup(
     entry_points={
         "console_scripts": ["loqusdb = loqusdb.__main__:base_command"],
     },
-    install_requires=requirements,
+    install_requires=install_requires,
     include_package_data=True,
     license="MIT",
     keywords=["vcf", "variants"],


### PR DESCRIPTION
### This PR adds | fixes:
- Flag to allow QUAL instead of GQ FORMAT tag filtering.

**How to prepare for test**:
- [x] `ssh` to hasta
- [x] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- test loading a tnscope somatic snv vcf (which has no GQ values)
- notice only SVs loading
- apply patch, and repeat with `--qual-gq` flag enabled

### Expected outcome:
- [x] notice both SNVs and SVs loading with `--qual-gq` flag enabled

### Review:
- [ ] Code approved by
- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
