### PR TITLE
Fix installing error due to PyYaml version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Fixed
+- `Deprecated config in setup.cfg` error when installing the package
+
+## [2.7.1]
 ### Added
 - Script to correct contig name
 - Expanded instructions on how to set up an instance and load data into database

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ click==7.1.2
 pymongo==3.7.1
 numpy==1.21.4
 coloredlogs==14.0
-pyyaml==5.4.0
+pyyaml>=5.4.1
 vcftoolbox==1.5
 pip==23.1.2
 setuptools==65.5.1


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #122 

Check also the issue on the PyYAML repo: https://github.com/yaml/pyyaml/issues/724

### How to test:
- Run pip install -e . from main branch and this branch

### Expected outcome:
- [x] The repo should install using this branch

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
