### PR TITLE
Unfreeze PyMongo and replace deprecated count() with count_documents()

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        mongodb-version: ["4.4", "5.0"]
+        mongodb-version: ["5", "7"]
 
     steps:
     # Check out Scout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [unreleased]
+## [2.8]
+### Added
+- Basic cli tests touching fixed deprecated code
 ### Changed
-- Un-freeze Pymongo and mongo_adapter collections
+- Unfreezed PyMongo in requirements.txt
+
+## [2.7.2]
 ### Fixed
 - `Deprecated config in setup.cfg` error when installing the package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Changed
+- Un-freeze Pymongo and mongo_adapter collections
 ### Fixed
 - `Deprecated config in setup.cfg` error when installing the package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 - Basic cli tests touching fixed deprecated code
 ### Changed
 - Unfreezed PyMongo in requirements.txt
+- Replaced deprecated pymongo `.count()` function with `count_documents()` in code.
 
 ## [2.7.2]
 ### Fixed

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,2 +1,0 @@
-uri: mongodb://localhost:27017/loqusdb-test
-db_name: loqusdb_test

--- a/conf.yaml
+++ b/conf.yaml
@@ -1,0 +1,2 @@
+uri: mongodb://localhost:27017/loqusdb-test
+db_name: loqusdb_test

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -39,7 +39,6 @@ def export(ctx, outfile, variant_type, freq):
     version = ctx.obj["version"]
 
     LOG.info("Export the variants from {0}".format(adapter))
-    nr_cases = 0
 
     is_sv = variant_type == "sv"
     existing_chromosomes = set(adapter.get_chromosomes(sv=is_sv))
@@ -52,7 +51,7 @@ def export(ctx, outfile, variant_type, freq):
     for chrom in existing_chromosomes:
         ordered_chromosomes.append(chrom)
 
-    nr_cases = adapter.cases().count()
+    nr_cases = adapter.cases().count_documents()
     LOG.info("Found {0} cases in database".format(nr_cases))
 
     head = HeaderParser()
@@ -85,7 +84,7 @@ def export(ctx, outfile, variant_type, freq):
         else:
             LOG.info("Collecting all SV variants")
             variants = adapter.get_sv_variants(chromosome=chrom)
-        LOG.info("{} variants found".format(variants.count()))
+        LOG.info("{} variants found".format(variants.count_documents()))
         for variant in variants:
             variant_line = format_variant(
                 variant, variant_type=variant_type, nr_cases=nr_cases, add_freq=freq

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -51,8 +51,8 @@ def export(ctx, outfile, variant_type, freq):
     for chrom in existing_chromosomes:
         ordered_chromosomes.append(chrom)
 
-    nr_cases = adapter.cases().count_documents()
-    LOG.info("Found {0} cases in database".format(nr_cases))
+    nr_cases = adapter.case_count()
+    LOG.info(f"Found {0} cases in database".format(nr_cases))
 
     head = HeaderParser()
     head.add_fileformat("VCFv4.3")

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -84,7 +84,7 @@ def export(ctx, outfile, variant_type, freq):
         else:
             LOG.info("Collecting all SV variants")
             variants = adapter.get_sv_variants(chromosome=chrom)
-        LOG.info("{} variants found".format(variants.count_documents()))
+        LOG.info(f"{adapter.nr_variants(chromosome=chrom)} variants found")
         for variant in variants:
             variant_line = format_variant(
                 variant, variant_type=variant_type, nr_cases=nr_cases, add_freq=freq

--- a/loqusdb/commands/export.py
+++ b/loqusdb/commands/export.py
@@ -52,7 +52,7 @@ def export(ctx, outfile, variant_type, freq):
         ordered_chromosomes.append(chrom)
 
     nr_cases = adapter.case_count()
-    LOG.info(f"Found {0} cases in database".format(nr_cases))
+    LOG.info(f"Found {nr_cases} cases in database")
 
     head = HeaderParser()
     head.add_fileformat("VCFv4.3")

--- a/loqusdb/commands/identity.py
+++ b/loqusdb/commands/identity.py
@@ -17,12 +17,11 @@ def identity(ctx, variant_id):
         ctx.abort()
 
     adapter = ctx.obj["adapter"]
-    version = ctx.obj["version"]
 
     LOG.info("Search variants {0}".format(adapter))
 
-    result = adapter.get_clusters(variant_id)
-    if result.count_documents() == 0:
+    nr_results = adapter.db.identity.count_documents({"variant_id": variant_id})
+    if nr_results == 0:
         LOG.info("No hits for variant %s", variant_id)
         return
 

--- a/loqusdb/commands/identity.py
+++ b/loqusdb/commands/identity.py
@@ -22,7 +22,7 @@ def identity(ctx, variant_id):
     LOG.info("Search variants {0}".format(adapter))
 
     result = adapter.get_clusters(variant_id)
-    if result.count() == 0:
+    if result.count_documents() == 0:
         LOG.info("No hits for variant %s", variant_id)
         return
 

--- a/loqusdb/commands/identity.py
+++ b/loqusdb/commands/identity.py
@@ -20,7 +20,7 @@ def identity(ctx, variant_id):
 
     LOG.info("Search variants {0}".format(adapter))
 
-    nr_results = adapter.db.identity.count_documents({"variant_id": variant_id})
+    variant_count: int = adapter.db.identity.count_documents({"variant_id": variant_id})
     if nr_results == 0:
         LOG.info("No hits for variant %s", variant_id)
         return

--- a/loqusdb/commands/identity.py
+++ b/loqusdb/commands/identity.py
@@ -22,7 +22,7 @@ def identity(ctx, variant_id):
 
     variant_count: int = adapter.db.identity.count_documents({"variant_id": variant_id})
     if variant_count == 0:
-        LOG.info("No hits for variant %s", variant_id)
+        LOG.info(f"No hits for variant {variant_id}")
         return
 
     for res in result:

--- a/loqusdb/commands/identity.py
+++ b/loqusdb/commands/identity.py
@@ -21,7 +21,7 @@ def identity(ctx, variant_id):
     LOG.info("Search variants {0}".format(adapter))
 
     variant_count: int = adapter.db.identity.count_documents({"variant_id": variant_id})
-    if nr_results == 0:
+    if variant_count == 0:
         LOG.info("No hits for variant %s", variant_id)
         return
 

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -42,10 +42,12 @@ def cases(ctx, case_id, to_json, count, case_type):
         case_obj["_id"] = str(case_obj["_id"])
         cases.append(case_obj)
     else:
-        cases = adapter.cases()
-        if cases.count_documents() == 0:
+
+        nr_cases = adapter.db.case.count_documents({})
+        if nr_cases == 0:
             LOG.info("No cases found in database")
             ctx.abort()
+        cases = adapter.cases()
 
     if to_json:
         click.echo(json.dumps(cases))

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -44,7 +44,7 @@ def cases(ctx, case_id, to_json, count, case_type):
     else:
 
         case_count: int = adapter.case_count()
-        if nr_cases == 0:
+        if case_count == 0:
             LOG.info("No cases found in database")
             ctx.abort()
         cases = adapter.cases()

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -43,7 +43,7 @@ def cases(ctx, case_id, to_json, count, case_type):
         cases.append(case_obj)
     else:
 
-        nr_cases = adapter.db.case.count_documents({})
+        nr_cases = adapter.case_count()
         if nr_cases == 0:
             LOG.info("No cases found in database")
             ctx.abort()

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -43,7 +43,7 @@ def cases(ctx, case_id, to_json, count, case_type):
         cases.append(case_obj)
     else:
         cases = adapter.cases()
-        if cases.count() == 0:
+        if cases.count_documents() == 0:
             LOG.info("No cases found in database")
             ctx.abort()
 

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from pprint import pprint as pp
+from pymongo.cursor import Cursor
 
 import click
 
@@ -42,12 +43,12 @@ def cases(ctx, case_id, to_json, count, case_type):
         case_obj["_id"] = str(case_obj["_id"])
         cases.append(case_obj)
     else:
-
         case_count: int = adapter.case_count()
         if case_count == 0:
             LOG.info("No cases found in database")
             ctx.abort()
-        cases = adapter.cases()
+        cases: Cursor = adapter.cases()
+
 
     if to_json:
         click.echo(json.dumps(cases))

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -43,7 +43,7 @@ def cases(ctx, case_id, to_json, count, case_type):
         cases.append(case_obj)
     else:
 
-        nr_cases = adapter.case_count()
+        case_count: int = adapter.case_count()
         if nr_cases == 0:
             LOG.info("No cases found in database")
             ctx.abort()

--- a/loqusdb/plugins/mongo/case.py
+++ b/loqusdb/plugins/mongo/case.py
@@ -105,7 +105,6 @@ class CaseMixin:
         returns:
             nr_of_cases (int): Total number of cases in database
         """
-        nr_of_cases = 0
         res = self.cases
 
-        return res.count()
+        return res.count_documents()

--- a/loqusdb/plugins/mongo/case.py
+++ b/loqusdb/plugins/mongo/case.py
@@ -99,12 +99,6 @@ class CaseMixin:
         LOG.info("Removing case {0} from database".format(mongo_case.get("case_id")))
         self.db.case.delete_one({"_id": mongo_case["_id"]})
 
-    def case_count(self):
-        """Returns the total number of cases in the database
-
-        returns:
-            nr_of_cases (int): Total number of cases in database
-        """
-        res = self.cases
-
-        return res.count_documents()
+    def case_count(self) -> int:
+        """Returns the total number of cases in the database."""
+        return self.db.case.count_documents({})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,13 @@
 pytest==5.4.3
 cyvcf2==0.30.12
-mongomock==3.18.0
+mongomock
 click==7.1.2
-pymongo==3.7.1
+pymongo
 numpy==1.21.4
 coloredlogs==14.0
 pyyaml>=5.4.1
 vcftoolbox==1.5
 pip==23.1.2
 setuptools==65.5.1
-mongo_adapter>=0.3.3
+mongo_adapter
 ped_parser

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -7,7 +7,7 @@ def test_export_base(real_db_name):
 
     runner = CliRunner()
 
-    # WHen the command to export cases is run
+    # WHEN the base command to export cases is run
     command = ["--database", real_db_name, "export"]
 
     ## THEN it should return success

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -1,0 +1,16 @@
+from click.testing import CliRunner
+
+from loqusdb.commands.cli import cli as base_command
+
+def test_export_base(real_db_name):
+    """Test the base command that exports variants."""
+
+    runner = CliRunner()
+
+    # WHen the command to export cases is run
+    command = ["--database", real_db_name, "export"]
+
+    ## THEN it should return success
+    result = runner.invoke(base_command, command)
+    assert result.exit_code == 0
+

--- a/tests/commands/test_export.py
+++ b/tests/commands/test_export.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 
 from loqusdb.commands.cli import cli as base_command
 
-def test_export_base(real_db_name):
+def test_export_base(real_db_name:str):
     """Test the base command that exports variants."""
 
     runner = CliRunner()

--- a/tests/commands/test_identity.py
+++ b/tests/commands/test_identity.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 
 from loqusdb.commands.cli import cli as base_command
 
-def test_identity(real_db_name):
+def test_identity(real_db_name:str):
     """Test the SV identity base command."""
 
     runner = CliRunner()

--- a/tests/commands/test_identity.py
+++ b/tests/commands/test_identity.py
@@ -1,0 +1,22 @@
+from click.testing import CliRunner
+
+from loqusdb.commands.cli import cli as base_command
+
+def test_identity(real_db_name):
+    """Test the SV identity base command."""
+
+    runner = CliRunner()
+
+    # WHEN the base identity command is run on an empty database
+    command = ["--database", real_db_name, "identity", "-v", "1_7890024_TGA_GGG"]
+
+    # THEN the command should return success
+    result = runner.invoke(base_command, command)
+    assert result.exit_code == 0
+
+    # AND no variant found message
+    assert "No hits for variant" in result.output
+
+
+
+

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -1,0 +1,17 @@
+from click.testing import CliRunner
+
+from loqusdb.commands.cli import cli as base_command
+
+def test_view_cases_no_cases(vcf_path, ped_path, real_mongo_adapter, real_db_name):
+    """Test the command that returns database cases."""
+
+    ## GIVEN an empty database
+    assert sum([1 for _ in real_mongo_adapter.cases()]) == 0
+
+    runner = CliRunner()
+
+    # THEN the case command should return No cases found error
+    command = ["--database", real_db_name, "cases" ]
+    result = runner.invoke(base_command, command)
+    assert result.exit_code == 1
+    assert "No cases found in database" in result.output

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 from loqusdb.plugins.mongo.adapter import MongoAdapter
 from loqusdb.commands.cli import cli as base_command
 
-def test_view_cases_base(real_mongo_adapter, real_db_name:str):
+def test_view_cases_base(real_mongo_adapter: MongoAdapter, real_db_name:str):
     """Test the base command that returns database cases."""
 
     ## GIVEN an empty database

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -3,7 +3,7 @@ from click.testing import CliRunner
 from loqusdb.commands.cli import cli as base_command
 
 def test_view_cases_no_cases(vcf_path, ped_path, real_mongo_adapter, real_db_name):
-    """Test the command that returns database cases."""
+    """Test the command that returns database cases when the database is empty."""
 
     ## GIVEN an empty database
     assert sum([1 for _ in real_mongo_adapter.cases()]) == 0

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -2,7 +2,7 @@ from click.testing import CliRunner
 
 from loqusdb.commands.cli import cli as base_command
 
-def test_view_cases_base(vcf_path, ped_path, real_mongo_adapter, real_db_name):
+def test_view_cases_base(real_mongo_adapter, real_db_name):
     """Test the base command that returns database cases."""
 
     ## GIVEN an empty database

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -1,8 +1,8 @@
 from click.testing import CliRunner
-
+from loqusdb.plugins.mongo.adapter import MongoAdapter
 from loqusdb.commands.cli import cli as base_command
 
-def test_view_cases_base(real_mongo_adapter, real_db_name):
+def test_view_cases_base(real_mongo_adapter, real_db_name:str):
     """Test the base command that returns database cases."""
 
     ## GIVEN an empty database

--- a/tests/commands/test_view.py
+++ b/tests/commands/test_view.py
@@ -2,8 +2,8 @@ from click.testing import CliRunner
 
 from loqusdb.commands.cli import cli as base_command
 
-def test_view_cases_no_cases(vcf_path, ped_path, real_mongo_adapter, real_db_name):
-    """Test the command that returns database cases when the database is empty."""
+def test_view_cases_base(vcf_path, ped_path, real_mongo_adapter, real_db_name):
+    """Test the base command that returns database cases."""
 
     ## GIVEN an empty database
     assert sum([1 for _ in real_mongo_adapter.cases()]) == 0


### PR DESCRIPTION
### This PR adds | fixes:
- Unfreezed PyMongo in requirements.txt
- Replaced deprecated pymongo `.count()` function with `count_documents()` in code.
- Added basic cli tests touching fixed deprecated code

### How to test:
- Automatic tests should pass

### Expected outcome:
- [x] All tests should pass

### Review:
- [x] Code approved by HS
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
