### PR TITLE
Fix #117 corollary - if QUAL is . set to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
+## [unreleased]
+## Changed
+- When using QUAL values, treat . as 0 quality
 
-## [2.8]
+## [2.7.3]
 ### Added
 - Basic cli tests touching fixed deprecated code
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
-## [unreleased]
+## [2.7.4]
 ## Changed
 - When using QUAL values, treat . as 0 quality
 

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -1,8 +1,12 @@
 import logging
 from collections import namedtuple
 
+import cyvcf2
+
+from typing import Optional
+
 from loqusdb.constants import CHROM_TO_INT, GENOTYPE_MAP, GRCH37, PAR
-from loqusdb.models import Variant
+from loqusdb.models import Case, Variant
 
 LOG = logging.getLogger(__name__)
 
@@ -139,19 +143,21 @@ def get_coords(variant):
     return coordinates
 
 
-def build_variant(variant, case_obj, case_id=None, gq_threshold=None, gq_qual=False, genome_build=None):
+def build_variant(variant:cyvcf2.Variant, case_obj:Case, case_id:Optional[str]=None, gq_threshold:Optional[int]=None, gq_qual:Optional[bool]=False, genome_build:Optional[str]=None) -> Variant:
     """Return a Variant object
 
     Take a cyvcf2 formated variant line and return a models.Variant.
 
-    If criterias are not fullfilled, eg. variant have no gt call or quality
+    If criteria are not fulfilled, eg variant has no gt call or quality
     is below gq threshold then return None.
+
 
     Args:
         variant(cyvcf2.Variant)
         case_obj(Case): We need the case object to check individuals sex
         case_id(str): The case id
         gq_threshold(int): Genotype Quality threshold
+        gq_qual(bool): Use variant.QUAL for quality instead of GQ
 
     Return:
         formated_variant(models.Variant): A variant dictionary
@@ -190,7 +196,9 @@ def build_variant(variant, case_obj, case_id=None, gq_threshold=None, gq_qual=Fa
             ind_pos = ind_obj["ind_index"]
 
             if gq_qual:
-                gq = int(variant.QUAL)
+                gq = 0
+                if variant.QUAL:
+                    gq = int(variant.QUAL)
 
             if not gq_qual:
                 gq = int(variant.gt_quals[ind_pos])

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -148,7 +148,7 @@ def build_variant(variant:cyvcf2.Variant, case_obj:Case, case_id:Optional[str]=N
 
     Take a cyvcf2 formated variant line and return a models.Variant.
 
-    If criteria are not fulfilled, eg variant has no gt call or quality
+    If criteria are not fulfilled, eg variant has no GT call or quality.
     is below gq threshold then return None.
 
 

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -143,7 +143,7 @@ def get_coords(variant):
     return coordinates
 
 
-def build_variant(variant:cyvcf2.Variant, case_obj:Case, case_id:Optional[str]=None, gq_threshold:Optional[int]=None, gq_qual:Optional[bool]=False, genome_build:Optional[str]=None) -> Variant:
+def build_variant(variant: cyvcf2.Variant, case_obj: Case, case_id: Optional[str]=None, gq_threshold: Optional[int]=None, gq_qual: Optional[bool]=False, genome_build: Optional[str]=None) -> Variant:
     """Return a Variant object
 
     Take a cyvcf2 formated variant line and return a models.Variant.

--- a/tests/vcf_tools/test_format_variant.py
+++ b/tests/vcf_tools/test_format_variant.py
@@ -21,6 +21,20 @@ def test_format_variant(het_variant, case_obj):
     assert formated_variant["homozygote"] == 0
 
 
+def test_format_variant_no_qual(variant_no_gq, case_obj):
+    ## GIVEN a variant without GQ
+    variant = variant_no_gq
+    ## And that has a missing QUAL value
+    variant.QUAL = None
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant using a QUAL threshold
+    formated_variant = build_variant(
+        variant=variant, case_obj=case_obj, case_id=case_id, gq_qual=True, gq_threshold=20
+    )
+    ## THEN assert that None is returned since requirements are not fulfilled
+    assert formated_variant is None
+
+
 def test_format_variant_no_gq(variant_no_gq, case_obj):
     ## GIVEN a variant without GQ
     variant = variant_no_gq


### PR DESCRIPTION
### This PR adds | fixes:
- Sentieon TNscope may set QUAL to `.` in addition to not outputting GQ for variants. Solve by setting gq 0 for these.

**How to prepare for test**:
- [x] `ssh` to ...
- [x] Install on stage:
`bash servers/resources/SERVER.scilifelab.se/update-[THIS_TOOL]-stage.sh [THIS-BRANCH-NAME]`

### How to test:
- load case with . in QUAL (e.g. selectbison)

### Expected outcome:
- [x] works with patch, not with master

### Review:
- [x] Code approved by HS, VI
- [x] Tests executed by DN
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
