### PR TITLE
Update setuptools to address a security issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
+
+## [2.7.7]
+### Fixed
+- Update to setuptools >= v.70 to address a security issue in the `package_index` module
+
+## [2.7.6]
+### Fixed
+- Updated issue templates
+
 ## [2.7.4]
 ## Changed
 - When using QUAL values, treat . as 0 quality

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ coloredlogs==14.0
 pyyaml>=5.4.1
 vcftoolbox==1.5
 pip==23.1.2
-setuptools==65.5.1
+setuptools>=70.0.0
 mongo_adapter
 ped_parser


### PR DESCRIPTION
## Description
### Fixed
- Update to setuptools >= v.70 to address a security issue in the `package_index` module (fix #134)

### How to test
- locally, pip install the repo and make sure it works


## Review

- [ ] Tests executed by CR
- [x] "Merge and deploy" approved by CO
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a

- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
