### PR TITLE
Bumpversion the changelog as well. Added changelog backlog.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -10,3 +10,9 @@ search = version = "{current_version}"
 replace = version = "{new_version}"
 
 [bumpversion:file:loqusdb/__init__.py]
+
+[bumpversion:file:CHANGELOG.md]
+search = ## [unreleased]
+replace = ## [unreleased]
+
+	## [v{new_version}]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Fixed
+- Update bumpversion config to also update the changelog version on bump (#147)
+
+## [2.7.12]
+### Changed
+- Update the description of the Frq INFO tag to include information about the number of cases as well. (#144)
+
+## [2.7.11]
+### Changed
+- Add linters (#143)
+
+## [2.7.10]
+### Changed
+- Add codeowners (#142)
+
+## [2.7.9]
+### Changed
+-Fix bump action (#141)
+
+## [2.7.8]
+### Changed
+- Fix Bump action (#137)
+
 ## [2.7.7]
 ### Fixed
 - Update to setuptools >= v.70 to address a security issue in the `package_index` module


### PR DESCRIPTION

## Description

- Bumpversion the changelog as well. Added changelog backlog from release notes for v2.7.8 - current.

The config is a bit ad lib - I am unsure how and if escaping of e.g. comment `#` works. 

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
