### PR TITLE
Fix bumpversion changelog

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -14,3 +14,4 @@ replace = version = "{new_version}"
 [bumpversion:file:CHANGELOG.md]
 search = ## [unreleased]
 replace = ## [unreleased]
+    ## [{new_version}]

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -13,5 +13,4 @@ replace = version = "{new_version}"
 
 [bumpversion:file:CHANGELOG.md]
 search = ## [unreleased]
-replace = ## [unreleased]
-    ## [{new_version}]
+replace = ## [{new_version}]

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -12,7 +12,7 @@ jobs:
   runs-on: ubuntu-latest
   steps:
    - name: Check out git repository
-     uses: actions/checkout@v3
+     uses: actions/checkout@v4
 
    - name: Set up Python
      uses: actions/setup-python@v5

--- a/.github/workflows/keep_a_changelog.yml
+++ b/.github/workflows/keep_a_changelog.yml
@@ -1,0 +1,15 @@
+name: "Changelog Reminder"
+on:
+  pull_request:
+      types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  # Enforces the update of a changelog file on every pull request
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: dangoslen/changelog-enforcer@v3
+      with:
+        changeLogPath: 'CHANGELOG.md'
+        skipLabels: 'Skip-Changelog'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,13 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
 ### Fixed
+- Fixed bumpversion changelog rule - attempted to anyway
+
+## [2.7.13]
+### Fixed
 - Update bumpversion config to also update the changelog version on bump (#147)
 
-## [## [unreleased]]
+## [2.7.12]
 ### Changed
 - Update the description of the Frq INFO tag to include information about the number of cases as well. (#144)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [unreleased]
+### Added
+- GitHub workflow for ChangeLog reminders 
 ### Fixed
-- Fixed bumpversion changelog rule - attempted to anyway
+- Fixed bumpversion changelog rule - attempted to anyway (#148)
 
 ## [2.7.13]
 ### Fixed


### PR DESCRIPTION
## Description
- bumpversion changelog rule did indeed not work as intended, specifically the multiline replacement was scuffed, and the rule was not propagated during bump of the cfg, presumably for looking like a commented line.
- added changelog reminder as an afterthought

✅ ![Screenshot 2025-04-03 at 12 37 03](https://github.com/user-attachments/assets/e9d0d894-9277-4525-b32e-486b27d70003)


### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
