### PR TITLE
add flag to skip GQ check on SV file --snv-gq-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
-## [2.7.16]
+## [2.7.17]
 ### Added
 - Flag to skip GQ check on SV files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [2.7.16]
+### Added
+- Flag to skip GQ check on SV files
 
 ## [2.7.16]
 ### Fixed 

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -88,6 +88,13 @@ def validate_profile_threshold(ctx, param, value):
     callback=validate_profile_threshold,
     help="profile hamming distance to store similar individuals (0-1)",
 )
+@click.option(
+    "--snv-gq-only",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Apply GQ threshold only to SNV variants",
+)
 @click.pass_context
 def load(
     ctx,
@@ -104,6 +111,7 @@ def load(
     hard_threshold,
     soft_threshold,
     qual_gq,
+    snv_gq_only,
 ):
     """Load the variants of a case
 
@@ -145,6 +153,7 @@ def load(
             skip_case_id=skip_case_id,
             case_id=case_id,
             gq_threshold=gq_threshold,
+            snv_gq_only=snv_gq_only,
             qual_gq=qual_gq,
             max_window=max_window,
             profile_file=variant_profile_path,


### PR DESCRIPTION
## Description
This PR adds the option of not checking for the GQ column in SV files. Context: in Nallo the SNV files have GQ information, but the SV files lack this. We want to skip this check for SV files.

### Added
- Flag to skip GQ check on SV files


### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b snv-gq-only`
- [ ] Using the filtered (clinical) files to test. Giving SNV and SV file, adding the gq-threshold 10, as well as the snv-gq-only flag.
- [ ] Next, delete all observations, and upload the snv separately, to make sure same number of snvs are uploaded as with the new flag.

### How to test
- [ ] Do `/home/proj/stage/bin/miniconda3/envs/S_loqusdb/bin/loqusdb --config /home/proj/stage/servers/config/hasta.scilifelab.se/loqusdb-lwp-stage.yaml load --case-id massivegopher --variant-file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz --sv-variants /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_svs_cnvs_merged_annotated_ranked_filtered.vcf.gz --check-profile /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz --family-file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher.ped --gq-threshold 10 --hard-threshold 0.95 --soft-threshold 0.9 --snv-gq-only`
- [ ] Do `/home/proj/stage/bin/miniconda3/envs/S_loqusdb/bin/loqusdb --config /home/proj/stage/servers/config/hasta.scilifelab.se/loqusdb-lwp-stage.yaml delete --case-id massivegopher`
- [ ] Do `/home/proj/stage/bin/miniconda3/envs/S_loqusdb/bin/loqusdb --config /home/proj/stage/servers/config/hasta.scilifelab.se/loqusdb-lwp-stage.yaml load --case-id massivegopher --variant-file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz --check-profile /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz --family-file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher.ped --gq-threshold 10 --hard-threshold 0.95 --soft-threshold 0.9`

### Expected test outcome
- [ ] Check that upload completes successfully, giving the same number of variants as when upload the files separately.
- [ ] Take a screenshot and attach or copy/paste the output.
```
2025-05-14 13:05:41 hasta.scilifelab.se loqusdb.commands.cli[42385] INFO Running loqusdb version 2.7.16
2025-05-14 13:05:41 hasta.scilifelab.se mongo_adapter.client[42385] INFO Connecting to uri:mongodb://loqusdb-stage:******@cg-mongo-stage.scilifelab.se:27030
2025-05-14 13:05:42 hasta.scilifelab.se mongo_adapter.client[42385] INFO Connection established
2025-05-14 13:05:42 hasta.scilifelab.se mongo_adapter.adapter[42385] INFO Use database loqusdb-rd-lwp-stage
2025-05-14 13:05:42 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Check if vcf is on correct format...
2025-05-14 13:05:50 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Vcf file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz looks fine
2025-05-14 13:05:50 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Nr of variants in vcf: 72430
2025-05-14 13:05:50 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Type of variants in vcf: snv
2025-05-14 13:05:50 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Check if vcf is on correct format...
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Vcf file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_svs_cnvs_merged_annotated_ranked_filtered.vcf.gz looks fine
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Nr of variants in vcf: 1780
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.vcf[42385] INFO Type of variants in vcf: sv
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.load[42385] INFO Loading family from /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher.ped
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.case[42385] INFO Parsing family information
2025-05-14 13:05:51 hasta.scilifelab.se loqusdb.utils.case[42385] INFO Found families massivegopher
Inserting variants  [------------------------------------]    0%
Inserting variants  [####################################]  100%          2025-05-14 13:06:08 hasta.scilifelab.se loqusdb.utils.load[42385] INFO Inserted 61322 variants of type snv
Inserting variants  [------------------------------------]    0%
Inserting variants  [####################################]  100%          2025-05-14 13:06:20 hasta.scilifelab.se loqusdb.utils.load[42385] INFO Inserted 1780 variants of type sv
2025-05-14 13:06:20 hasta.scilifelab.se loqusdb.commands.load[42385] INFO Nr variants inserted: 63102
2025-05-14 13:06:20 hasta.scilifelab.se loqusdb.commands.load[42385] INFO Time to insert variants: 0:00:38.798345
2025-05-14 13:06:20 hasta.scilifelab.se loqusdb.plugins.mongo.adapter[42385] INFO All indexes exists
```
- [ ] SNVs only, gives same number of variants.
```
2025-05-14 13:11:00 hasta.scilifelab.se loqusdb.commands.cli[47048] INFO Running loqusdb version 2.7.16
2025-05-14 13:11:00 hasta.scilifelab.se mongo_adapter.client[47048] INFO Connecting to uri:mongodb://loqusdb-stage:******@cg-mongo-stage.scilifelab.se:27030
2025-05-14 13:11:01 hasta.scilifelab.se mongo_adapter.client[47048] INFO Connection established
2025-05-14 13:11:01 hasta.scilifelab.se mongo_adapter.adapter[47048] INFO Use database loqusdb-rd-lwp-stage
2025-05-14 13:11:01 hasta.scilifelab.se loqusdb.utils.vcf[47048] INFO Check if vcf is on correct format...
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.vcf[47048] INFO Vcf file /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher_snvs_annotated_ranked_filtered.vcf.gz looks fine
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.vcf[47048] INFO Nr of variants in vcf: 72430
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.vcf[47048] INFO Type of variants in vcf: snv
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.load[47048] INFO Loading family from /home/proj/stage/housekeeper-bundles/massivegopher/2025-04-02/massivegopher.ped
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.case[47048] INFO Parsing family information
2025-05-14 13:11:09 hasta.scilifelab.se loqusdb.utils.case[47048] INFO Found families massivegopher
Inserting variants  [------------------------------------]    0%
Inserting variants  [####################################]  100%          2025-05-14 13:11:26 hasta.scilifelab.se loqusdb.utils.load[47048] INFO Inserted 61322 variants of type snv
2025-05-14 13:11:26 hasta.scilifelab.se loqusdb.commands.load[47048] INFO Nr variants inserted: 61322
2025-05-14 13:11:26 hasta.scilifelab.se loqusdb.commands.load[47048] INFO Time to insert variants: 0:00:25.555655
2025-05-14 13:11:26 hasta.scilifelab.se loqusdb.plugins.mongo.adapter[47048] INFO All indexes exists
```

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
