### PR TITLE
Ignore gq check if unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- `ignore-gq-if-unset` flag to ignore GQ threshold check when GQ or QUAL field is unset for some variants in a VCF file.
+
 ## [2.7.17]
 ### Added
 - Flag to skip GQ check on SV files

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -148,6 +148,7 @@ def build_variant(
     case_id: Optional[str] = None,
     gq_threshold: Optional[int] = None,
     gq_qual: Optional[bool] = False,
+    ignore_gq_if_unset: Optional[bool]=False,
     genome_build: Optional[str] = None,
 ) -> Variant:
     """Return a Variant object
@@ -164,6 +165,8 @@ def build_variant(
         case_id(str): The case id
         gq_threshold(int): Genotype Quality threshold
         gq_qual(bool): Use variant.QUAL for quality instead of GQ
+        ignore_gq_if_unset(bool): Ignore GQ threshold check for variants that do not have GQ or QUAL set.
+        genome_build(str): Genome build. Ex. GRCh37 or GRCh38
 
     Return:
         formated_variant(models.Variant): A variant dictionary
@@ -208,8 +211,9 @@ def build_variant(
             if not gq_qual:
                 gq = int(variant.gt_quals[ind_pos])
 
-            if gq_threshold and gq < gq_threshold:
-                continue
+            if not ignore_gq_if_unset:
+                if gq_threshold and gq < gq_threshold:
+                    continue
 
             genotype = GENOTYPE_MAP[variant.gt_types[ind_pos]]
 

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -148,7 +148,7 @@ def build_variant(
     case_id: Optional[str] = None,
     gq_threshold: Optional[int] = None,
     gq_qual: Optional[bool] = False,
-    ignore_gq_if_unset: Optional[bool]=False,
+    ignore_gq_if_unset: Optional[bool] = False,
     genome_build: Optional[str] = None,
 ) -> Variant:
     """Return a Variant object

--- a/loqusdb/build_models/variant.py
+++ b/loqusdb/build_models/variant.py
@@ -204,16 +204,16 @@ def build_variant(
             ind_pos = ind_obj["ind_index"]
 
             if gq_qual:
-                gq = 0
+                gq = -1
                 if variant.QUAL:
                     gq = int(variant.QUAL)
 
             if not gq_qual:
                 gq = int(variant.gt_quals[ind_pos])
 
-            if not ignore_gq_if_unset:
-                if gq_threshold and gq < gq_threshold:
-                    continue
+            # When gq is missing in FORMAT cyvcf2 assigns a score of -1
+            if (gq_threshold and 0 <= gq < gq_threshold) or (gq == -1 and not ignore_gq_if_unset):
+                continue
 
             genotype = GENOTYPE_MAP[variant.gt_types[ind_pos]]
 

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -95,6 +95,13 @@ def validate_profile_threshold(ctx, param, value):
     show_default=True,
     help="Apply GQ threshold only to SNV variants",
 )
+@click.option(
+    "--ignore-gq-if-unset",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Ignore GQ threshold if GQ or QUAL field is unset in VCF",
+)
 @click.pass_context
 def load(
     ctx,
@@ -112,6 +119,7 @@ def load(
     soft_threshold,
     qual_gq,
     snv_gq_only,
+    ignore_gq_if_unset,
 ):
     """Load the variants of a case
 
@@ -160,6 +168,7 @@ def load(
             hard_threshold=hard_threshold,
             soft_threshold=soft_threshold,
             genome_build=genome_build,
+            ignore_gq_if_unset=ignore_gq_if_unset
         )
     except (SyntaxError, CaseError, IOError) as error:
         LOG.warning(error)

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -100,7 +100,7 @@ def validate_profile_threshold(ctx, param, value):
     is_flag=True,
     default=False,
     show_default=True,
-    help="Ignore GQ threshold if GQ or QUAL field is unset in VCF",
+    help="Ignore GQ threshold if GQ (or the QUAL field for --qual-gq) is unset in VCF",
 )
 @click.pass_context
 def load(

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -168,7 +168,7 @@ def load(
             hard_threshold=hard_threshold,
             soft_threshold=soft_threshold,
             genome_build=genome_build,
-            ignore_gq_if_unset=ignore_gq_if_unset
+            ignore_gq_if_unset=ignore_gq_if_unset,
         )
     except (SyntaxError, CaseError, IOError) as error:
         LOG.warning(error)

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -237,7 +237,13 @@ def load_variants(
 
         variants = (
             build_variant(
-                variant, case_obj, case_id, gq_threshold, qual_gq, ignore_gq_if_unset, genome_build=genome_build,
+                variant,
+                case_obj,
+                case_id,
+                gq_threshold,
+                qual_gq,
+                ignore_gq_if_unset,
+                genome_build=genome_build,
             )
             for variant in bar
         )

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -39,6 +39,7 @@ def load_database(
     hard_threshold=0.95,
     soft_threshold=0.9,
     genome_build=None,
+    ignore_gq_if_unset=False,
 ):
     """Load the database with a case and its variants
 
@@ -56,6 +57,8 @@ def load_database(
           check_profile(bool): Does profile check if True
           hard_threshold(float): Rejects load if hamming distance above this is found
           soft_threshold(float): Stores similar samples if hamming distance above this is found
+          genome_build(str): Store the genome version
+          ignore_gq_if_unset(str): Ignore the gq threhsold check for variants that do not have a GQ or QUAL set
 
     Returns:
           nr_inserted(int)
@@ -152,6 +155,7 @@ def load_database(
                 max_window=max_window,
                 variant_type=variant_type,
                 genome_build=genome_build,
+                ignore_gq_if_unset=ignore_gq_if_unset,
             )
         except Exception as err:
             # If something went wrong do a rollback
@@ -199,18 +203,22 @@ def load_variants(
     max_window=3000,
     variant_type="snv",
     genome_build=None,
+    ignore_gq_if_unset=False,
 ):
     """Load variants for a family into the database.
 
     Args:
         adapter (loqusdb.plugins.Adapter): initialized plugin
+        vcf_obj(cyvcf2.VCF): Iterable with cyvcf2.Variant
         case_obj(Case): dict with case information
-        nr_variants(int)
         skip_case_id (bool): whether to include the case id on variant level
                              or not
         gq_threshold(int)
+        qual_gq(bool): whether to use QUAL instead of GQ
         max_window(int): Specify the max size for sv windows
         variant_type(str): 'sv' or 'snv'
+        genome_build(str): Genome version. Ex. GRCH37
+        ignore_gq_if_unset (bool): whether to add entries that have missing GQ or QUAL field
 
     Returns:
         nr_inserted(int)
@@ -229,7 +237,7 @@ def load_variants(
 
         variants = (
             build_variant(
-                variant, case_obj, case_id, gq_threshold, qual_gq, genome_build=genome_build
+                variant, case_obj, case_id, gq_threshold, qual_gq, ignore_gq_if_unset, genome_build=genome_build,
             )
             for variant in bar
         )


### PR DESCRIPTION
## Description

Added`ignore-gq-if-unset` flag to ignore GQ threshold check when GQ or QUAL field is unset for some variants in a VCF file. Some callers, like Mutect2, do not generate GQ entries for variants. This flag allows us to load those variants as well.

Screen shot of test runs with different flags
<img width="1222" alt="Screenshot 2025-05-17 at 14 06 06" src="https://github.com/user-attachments/assets/69aa3c38-401a-4836-bcb8-961e3e0d1bf3" />
<img width="1215" alt="Screenshot 2025-05-17 at 14 06 22" src="https://github.com/user-attachments/assets/9b842cc4-fe67-450e-b246-e148c3beb2c2" />

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
