### PR TITLE
Keep chr prefix when present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Added
+- Flag to retain chr/CHR/Chr prefixes when they are present
+
 ## [2.7.17]
 ### Added
 - Flag to skip GQ check on SV files

--- a/loqusdb/build_models/profile_variant.py
+++ b/loqusdb/build_models/profile_variant.py
@@ -24,23 +24,25 @@ def get_maf(variant):
     return variant.INFO.get("MAF")
 
 
-def build_profile_variant(variant):
+def build_profile_variant(variant, keep_chr_prefix=None):
     """Returns a ProfileVariant object
 
     Args:
         variant (cyvcf2.Variant)
+        keep_chr_prefix(bool): Retain chr/CHR/Chr prefix when present
 
     Returns:
         variant (models.ProfileVariant)
     """
 
     chrom = variant.CHROM
-    if chrom.startswith(("chr", "CHR", "Chr")):
-        chrom = chrom[3:]
+    if not keep_chr_prefix:
+        if chrom.startswith(("chr", "CHR", "Chr")):
+            chrom = chrom[3:]
 
     pos = int(variant.POS)
 
-    variant_id = get_variant_id(variant)
+    variant_id = get_variant_id(variant, keep_chr_prefix)
 
     ref = variant.REF
     alt = variant.ALT[0]

--- a/loqusdb/commands/annotate.py
+++ b/loqusdb/commands/annotate.py
@@ -21,6 +21,7 @@ LOG = logging.getLogger(__name__)
 def annotate(ctx, variant_file, sv):
     """Annotate the variants in a VCF"""
     adapter = ctx.obj["adapter"]
+    keep_chr_prefix = ctx.obj["keep_chr_prefix"]
 
     variant_path = os.path.abspath(variant_file)
 
@@ -40,9 +41,9 @@ def annotate(ctx, variant_file, sv):
     start_inserting = datetime.now()
 
     if sv:
-        annotated_variants = annotate_svs(adapter, vcf_obj)
+        annotated_variants = annotate_svs(adapter, vcf_obj, keep_chr_prefix)
     else:
-        annotated_variants = annotate_snvs(adapter, vcf_obj)
+        annotated_variants = annotate_snvs(adapter, vcf_obj, keep_chr_prefix)
     # try:
     for variant in annotated_variants:
         click.echo(str(variant).rstrip())

--- a/loqusdb/commands/cli.py
+++ b/loqusdb/commands/cli.py
@@ -55,11 +55,18 @@ LOG = logging.getLogger(__name__)
     type=click.Choice([GRCH37, GRCH38]),
     help="Specify what genome build to use",
 )
+@click.option(
+    "--keep-chr-prefix",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Retain the 'chr/Chr/CHR' prefix for chromosomes if it is present",
+)
 @click.option("-v", "--verbose", is_flag=True)
 @click.version_option(__version__)
 @click.pass_context
 def cli(
-    ctx, database, username, password, authdb, port, host, uri, verbose, config, test, genome_build
+    ctx, database, username, password, authdb, port, host, uri, verbose, config, test, genome_build, keep_chr_prefix
 ):
     """loqusdb: manage a local variant count database."""
     loglevel = "INFO"
@@ -103,6 +110,7 @@ def cli(
     adapter = MongoAdapter(client, db_name=database)
 
     genome_build = genome_build or configs.get("genome_build") or GRCH37
+    keep_chr_prefix = keep_chr_prefix or configs.get("keep_chr_prefix")
 
     ctx.obj = {}
     ctx.obj["db"] = database
@@ -114,3 +122,4 @@ def cli(
     ctx.obj["adapter"] = adapter
     ctx.obj["version"] = __version__
     ctx.obj["genome_build"] = genome_build
+    ctx.obj["keep_chr_prefix"] = keep_chr_prefix

--- a/loqusdb/commands/cli.py
+++ b/loqusdb/commands/cli.py
@@ -66,7 +66,19 @@ LOG = logging.getLogger(__name__)
 @click.version_option(__version__)
 @click.pass_context
 def cli(
-    ctx, database, username, password, authdb, port, host, uri, verbose, config, test, genome_build, keep_chr_prefix
+    ctx,
+    database,
+    username,
+    password,
+    authdb,
+    port,
+    host,
+    uri,
+    verbose,
+    config,
+    test,
+    genome_build,
+    keep_chr_prefix,
 ):
     """loqusdb: manage a local variant count database."""
     loglevel = "INFO"

--- a/loqusdb/commands/delete.py
+++ b/loqusdb/commands/delete.py
@@ -60,7 +60,12 @@ def delete(ctx, family_file, family_type, case_id):
     genome_build = ctx.obj["genome_build"]
     start_deleting = datetime.now()
     try:
-        delete_command(adapter=adapter, case_obj=existing_case, genome_build=genome_build, keep_chr_prefix=keep_chr_prefix)
+        delete_command(
+            adapter=adapter,
+            case_obj=existing_case,
+            genome_build=genome_build,
+            keep_chr_prefix=keep_chr_prefix,
+        )
     except (CaseError, IOError) as error:
         LOG.warning(error)
         ctx.abort()

--- a/loqusdb/commands/delete.py
+++ b/loqusdb/commands/delete.py
@@ -35,6 +35,7 @@ def delete(ctx, family_file, family_type, case_id):
         ctx.abort()
 
     adapter = ctx.obj["adapter"]
+    keep_chr_prefix = ctx.obj["keep_chr_prefix"]
 
     # Get a ped_parser.Family object from family file
     family = None
@@ -59,7 +60,7 @@ def delete(ctx, family_file, family_type, case_id):
     genome_build = ctx.obj["genome_build"]
     start_deleting = datetime.now()
     try:
-        delete_command(adapter=adapter, case_obj=existing_case, genome_build=genome_build)
+        delete_command(adapter=adapter, case_obj=existing_case, genome_build=genome_build, keep_chr_prefix=keep_chr_prefix)
     except (CaseError, IOError) as error:
         LOG.warning(error)
         ctx.abort()

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -140,7 +140,7 @@ def load(
 
     adapter = ctx.obj["adapter"]
     genome_build = ctx.obj["genome_build"]
-
+    keep_chr_prefix = ctx.obj["keep_chr_prefix"]
     start_inserting = datetime.now()
 
     try:
@@ -154,6 +154,7 @@ def load(
             case_id=case_id,
             gq_threshold=gq_threshold,
             snv_gq_only=snv_gq_only,
+            keep_chr_prefix=keep_chr_prefix,
             qual_gq=qual_gq,
             max_window=max_window,
             profile_file=variant_profile_path,

--- a/loqusdb/commands/load_profile.py
+++ b/loqusdb/commands/load_profile.py
@@ -60,13 +60,14 @@ def load_profile(ctx, load, variant_file, update, stats, profile_threshold, chec
     """
 
     adapter = ctx.obj["adapter"]
+    keep_chr_prefix = ctx.obj["keep_chr_prefix"]
 
     LOG.info("Running loqusdb profile")
 
     if check_vcf:
         LOG.info(f"Check if profile in {check_vcf} has match in database")
         vcf_file = check_vcf
-        profiles = get_profiles(adapter, vcf_file)
+        profiles = get_profiles(adapter, vcf_file, keep_chr_prefix)
         duplicate = check_duplicates(adapter, profiles, profile_threshold)
 
         if duplicate is not None:
@@ -81,11 +82,11 @@ def load_profile(ctx, load, variant_file, update, stats, profile_threshold, chec
         if variant_file is not None:
             vcf_path = variant_file
         LOG.info(f"Loads variants in {vcf_path} to be used in profiling")
-        load_profile_variants(adapter, vcf_path)
+        load_profile_variants(adapter, vcf_path, keep_chr_prefix)
 
     if update:
         LOG.info("Updates profiles in database")
-        update_profiles(adapter)
+        update_profiles(adapter, keep_chr_prefix)
 
     if stats:
         LOG.info("Prints profile stats")

--- a/loqusdb/utils/annotate.py
+++ b/loqusdb/utils/annotate.py
@@ -31,21 +31,7 @@ def annotate_variant(variant, var_obj=None):
     return variant
 
 
-def annotate_snv(adpter, variant):
-    """Annotate an SNV/INDEL variant
-
-    Args:
-        adapter(loqusdb.plugin.adapter)
-        variant(cyvcf2.Variant)
-    """
-    variant_id = get_variant_id(variant)
-    variant_obj = adapter.get_variant(variant={"_id": variant_id})
-
-    annotated_variant = annotated_variant(variant, variant_obj)
-    return annotated_variant
-
-
-def annotate_svs(adapter, vcf_obj):
+def annotate_svs(adapter, vcf_obj, keep_chr_prefix):
     """Annotate all SV variants in a VCF
 
     Args:
@@ -56,14 +42,14 @@ def annotate_svs(adapter, vcf_obj):
         variant(cyvcf2.Variant)
     """
     for nr_variants, variant in enumerate(vcf_obj, 1):
-        variant_info = get_coords(variant)
+        variant_info = get_coords(variant, keep_chr_prefix)
         match = adapter.get_structural_variant(variant_info)
         if match:
             annotate_variant(variant, match)
         yield variant
 
 
-def annotate_snvs(adapter, vcf_obj):
+def annotate_snvs(adapter, vcf_obj, keep_chr_prefix):
     """Annotate all variants in a VCF
 
     Args:
@@ -77,7 +63,7 @@ def annotate_snvs(adapter, vcf_obj):
 
     for nr_variants, variant in enumerate(vcf_obj, 1):
         # Add the variant to current batch
-        variants[get_variant_id(variant)] = variant
+        variants[get_variant_id(variant, keep_chr_prefix)] = variant
         # If batch len == 1000 we annotate the batch
         if (nr_variants % 1000) == 0:
 

--- a/loqusdb/utils/delete.py
+++ b/loqusdb/utils/delete.py
@@ -9,7 +9,9 @@ from loqusdb.build_models.variant import build_variant
 LOG = logging.getLogger(__name__)
 
 
-def delete(adapter, case_obj, keep_chr_prefix=None, update=False, existing_case=False, genome_build=None):
+def delete(
+    adapter, case_obj, keep_chr_prefix=None, update=False, existing_case=False, genome_build=None
+):
     """Delete a case and all of it's variants from the database.
 
     Args:
@@ -37,19 +39,22 @@ def delete(adapter, case_obj, keep_chr_prefix=None, update=False, existing_case=
         if file_type == "vcf_path":
             LOG.info("deleting variants")
             delete_variants(
-                adapter=adapter, vcf_obj=vcf_obj, keep_chr_prefix=keep_chr_prefix, case_obj=case_obj, genome_build=genome_build
+                adapter=adapter,
+                vcf_obj=vcf_obj,
+                keep_chr_prefix=keep_chr_prefix,
+                case_obj=case_obj,
+                genome_build=genome_build,
             )
         elif file_type == "vcf_sv_path":
             LOG.info("deleting structural variants")
             delete_structural_variants(
-                adapter=adapter,
-                vcf_obj=vcf_obj,
-                case_obj=case_obj,
-                keep_chr_prefix=keep_chr_prefix
+                adapter=adapter, vcf_obj=vcf_obj, case_obj=case_obj, keep_chr_prefix=keep_chr_prefix
             )
 
 
-def delete_variants(adapter, vcf_obj, case_obj, keep_chr_prefix=None, case_id=None, genome_build=None):
+def delete_variants(
+    adapter, vcf_obj, case_obj, keep_chr_prefix=None, case_id=None, genome_build=None
+):
     """Delete variants for a case in the database
 
     Args:
@@ -71,7 +76,11 @@ def delete_variants(adapter, vcf_obj, case_obj, keep_chr_prefix=None, case_id=No
     variant_list = []
     for variant in vcf_obj:
         formated_variant = build_variant(
-            variant=variant, case_obj=case_obj, keep_chr_prefix=keep_chr_prefix, case_id=case_id, genome_build=genome_build
+            variant=variant,
+            case_obj=case_obj,
+            keep_chr_prefix=keep_chr_prefix,
+            case_id=case_id,
+            genome_build=genome_build,
         )
 
         if not formated_variant:
@@ -132,10 +141,7 @@ def delete_structural_variants(adapter, vcf_obj, case_obj, keep_chr_prefix=None,
 
     for variant in vcf_obj:
         formated_variant = build_variant(
-            variant=variant,
-            case_obj=case_obj,
-            case_id=case_id,
-            keep_chr_prefix=keep_chr_prefix
+            variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=keep_chr_prefix
         )
 
         if not formated_variant:

--- a/loqusdb/utils/delete.py
+++ b/loqusdb/utils/delete.py
@@ -9,7 +9,7 @@ from loqusdb.build_models.variant import build_variant
 LOG = logging.getLogger(__name__)
 
 
-def delete(adapter, case_obj, update=False, existing_case=False, genome_build=None):
+def delete(adapter, case_obj, keep_chr_prefix=None, update=False, existing_case=False, genome_build=None):
     """Delete a case and all of it's variants from the database.
 
     Args:
@@ -18,6 +18,7 @@ def delete(adapter, case_obj, update=False, existing_case=False, genome_build=No
         update(bool): If we are in the middle of an update
         existing_case(models.Case): If something failed during an update we need to revert
                                     to the original case
+        keep_chr_prefix(bool): Retain chr/CHR/Chr prefixes in chromosome IDs when they are present
 
     """
     # This will overwrite the updated case with the previous one
@@ -36,7 +37,7 @@ def delete(adapter, case_obj, update=False, existing_case=False, genome_build=No
         if file_type == "vcf_path":
             LOG.info("deleting variants")
             delete_variants(
-                adapter=adapter, vcf_obj=vcf_obj, case_obj=case_obj, genome_build=genome_build
+                adapter=adapter, vcf_obj=vcf_obj, keep_chr_prefix=keep_chr_prefix, case_obj=case_obj, genome_build=genome_build
             )
         elif file_type == "vcf_sv_path":
             LOG.info("deleting structural variants")
@@ -44,10 +45,11 @@ def delete(adapter, case_obj, update=False, existing_case=False, genome_build=No
                 adapter=adapter,
                 vcf_obj=vcf_obj,
                 case_obj=case_obj,
+                keep_chr_prefix=keep_chr_prefix
             )
 
 
-def delete_variants(adapter, vcf_obj, case_obj, case_id=None, genome_build=None):
+def delete_variants(adapter, vcf_obj, case_obj, keep_chr_prefix=None, case_id=None, genome_build=None):
     """Delete variants for a case in the database
 
     Args:
@@ -69,7 +71,7 @@ def delete_variants(adapter, vcf_obj, case_obj, case_id=None, genome_build=None)
     variant_list = []
     for variant in vcf_obj:
         formated_variant = build_variant(
-            variant=variant, case_obj=case_obj, case_id=case_id, genome_build=genome_build
+            variant=variant, case_obj=case_obj, keep_chr_prefix=keep_chr_prefix, case_id=case_id, genome_build=genome_build
         )
 
         if not formated_variant:
@@ -109,7 +111,7 @@ def delete_variants(adapter, vcf_obj, case_obj, case_id=None, genome_build=None)
     return nr_deleted
 
 
-def delete_structural_variants(adapter, vcf_obj, case_obj, case_id=None):
+def delete_structural_variants(adapter, vcf_obj, case_obj, keep_chr_prefix=None, case_id=None):
     """Delete structural variants for a case in the database
 
     Args:
@@ -133,6 +135,7 @@ def delete_structural_variants(adapter, vcf_obj, case_obj, case_id=None):
             variant=variant,
             case_obj=case_obj,
             case_id=case_id,
+            keep_chr_prefix=keep_chr_prefix
         )
 
         if not formated_variant:

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -234,7 +234,13 @@ def load_variants(
 
         variants = (
             build_variant(
-                variant, case_obj, case_id, gq_threshold, qual_gq, keep_chr_prefix, genome_build=genome_build
+                variant,
+                case_obj,
+                case_id,
+                gq_threshold,
+                qual_gq,
+                keep_chr_prefix,
+                genome_build=genome_build,
             )
             for variant in bar
         )

--- a/loqusdb/utils/profiling.py
+++ b/loqusdb/utils/profiling.py
@@ -11,7 +11,7 @@ from .vcf import get_file_handle
 LOG = logging.getLogger(__name__)
 
 
-def get_profiles(adapter, vcf_file):
+def get_profiles(adapter, vcf_file, keep_chr_prefix):
     """Given a vcf, get a profile string for each sample in the vcf
     based on the profile variants in the database
 
@@ -44,7 +44,7 @@ def get_profiles(adapter, vcf_file):
         found_variant = False
         for variant in vcf(region):
 
-            variant_id = get_variant_id(variant)
+            variant_id = get_variant_id(variant, keep_chr_prefix)
 
             # If variant id i.e. chrom_pos_ref_alt matches
             if variant_id == profile_variant["_id"]:
@@ -183,7 +183,7 @@ def compare_profiles(profile1, profile2):
     return similarity_ratio
 
 
-def update_profiles(adapter):
+def update_profiles(adapter, keep_chr_prefix):
     """
     For all cases having vcf_path, update the profile string for the samples
 
@@ -198,7 +198,7 @@ def update_profiles(adapter):
         # case with new profiled individuals.
         if case.get("profile_path"):
 
-            profiles = get_profiles(adapter, case["profile_path"])
+            profiles = get_profiles(adapter, case["profile_path"], keep_chr_prefix)
             profiled_individuals = deepcopy(case["individuals"])
 
             for individual in profiled_individuals:

--- a/loqusdb/utils/vcf.py
+++ b/loqusdb/utils/vcf.py
@@ -89,7 +89,7 @@ def check_sorting(previous_chrom, previous_pos, current_chrom, current_pos):
     pass
 
 
-def check_vcf(vcf_path, expected_type="snv"):
+def check_vcf(vcf_path, keep_chr_prefix=None, expected_type="snv"):
     """Check if there are any problems with the vcf file
 
     Args:
@@ -113,7 +113,7 @@ def check_vcf(vcf_path, expected_type="snv"):
     previous_pos = None
     previous_chrom = None
 
-    posititon_variants = set()
+    position_variants = set()
 
     nr_variants = 0
     for nr_variants, variant in enumerate(vcf, 1):
@@ -134,36 +134,36 @@ def check_vcf(vcf_path, expected_type="snv"):
         variant_id = "{0}_{1}".format(current_chrom, current_pos)
         # For SNVs we can create a proper variant id with chrom_pos_ref_alt
         if variant_type == "snv":
-            variant_id = get_variant_id(variant)
+            variant_id = get_variant_id(variant, keep_chr_prefix)
 
         # Initiate variables
         if not previous_chrom:
             previous_chrom = current_chrom
             previous_pos = current_pos
-            posititon_variants = {variant_id}
+            position_variants = {variant_id}
             continue
 
         # Update variables if new chromosome
         if current_chrom != previous_chrom:
             previous_chrom = current_chrom
             previous_pos = current_pos
-            posititon_variants = {variant_id}
+            position_variants = {variant_id}
             continue
 
         if variant_type == "snv":
             # Check if variant is unique
             if current_pos == previous_pos:
-                if variant_id in posititon_variants:
+                if variant_id in position_variants:
                     raise VcfError("Variant {0} occurs several times" " in vcf".format(variant_id))
                 else:
-                    posititon_variants.add(variant_id)
+                    position_variants.add(variant_id)
             # Check if vcf is sorted
             else:
                 if not current_pos >= previous_pos:
                     raise VcfError("Vcf if not sorted in a correct way")
                 previous_pos = current_pos
-                # Reset posititon_variants since we are on a new position
-                posititon_variants = {variant_id}
+                # Reset position_variants since we are on a new position
+                position_variants = {variant_id}
 
     if variant_type != expected_type:
         raise VcfError(

--- a/tests/build_models/test_build_variant.py
+++ b/tests/build_models/test_build_variant.py
@@ -9,7 +9,7 @@ def test_build_het_variant(het_variant, case_obj):
 
 
 def test_get_coords_for_BND(bnd_variant):
-    coords = get_coords(bnd_variant)
+    coords = get_coords(bnd_variant, True)
     assert coords["pos"] == coords["end"]
     assert coords["sv_length"] == float("inf")
     assert coords["sv_type"] == "BND"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -436,3 +436,68 @@ def translocation_variant(request):
         var_type="sv",
         info_dict={"END": None, "SVLEN": None, "SVTYPE": "BND"},
     )
+
+##SVs with chr prefix
+@pytest.fixture(scope="function")
+def chr_del_variant(request):
+    return CyvcfVariant(
+        chrom="chr1",
+        ref="G",
+        alt="<DEL>",
+        pos=1285001,
+        end=1287000,
+        var_type="sv",
+        info_dict={"END": 1287000, "SVLEN": -20000, "SVTYPE": "DEL"},
+    )
+
+
+@pytest.fixture(scope="function")
+def chr_small_insert_variant(request):
+    return CyvcfVariant(
+        chrom="chr1",
+        ref="G",
+        alt="GGGACGGGGGTTCTGAGATAAGCAAGCCCCCACCAGGTGAGACCGGCGGAGCTGTGGCCACCGAGGTCCCGGGAGCTGGTGCT",
+        pos=3021145,
+        end=3021145,
+        var_type="sv",
+        info_dict={"END": 3021145, "SVLEN": 82, "SVTYPE": "INS"},
+    )
+
+
+@pytest.fixture(scope="function")
+def chr_insertion_variant(request):
+    return CyvcfVariant(
+        chrom="chr1",
+        ref="A",
+        alt="<INS>",
+        pos=3177306,
+        end=3177306,
+        var_type="sv",
+        info_dict={"END": 3177306, "SVLEN": None, "SVTYPE": "INS"},
+    )
+
+
+@pytest.fixture(scope="function")
+def chr_duptandem_variant(request):
+    return CyvcfVariant(
+        chrom="chr1",
+        ref="A",
+        alt="<DUP:TANDEM>",
+        pos=3092626,
+        end=3092849,
+        var_type="sv",
+        info_dict={"END": 3092849, "SVLEN": 223, "SVTYPE": "DUP"},
+    )
+
+
+@pytest.fixture(scope="function")
+def chr_translocation_variant(request):
+    return CyvcfVariant(
+        chrom="chr1",
+        ref="N",
+        alt="N[11:119123896[",
+        pos=3754913,
+        end=3754913,
+        var_type="sv",
+        info_dict={"END": None, "SVLEN": None, "SVTYPE": "BND"},
+    )

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -6,7 +6,7 @@ from loqusdb.exceptions import ProfileError
 
 def test_base_command():
     runner = CliRunner()
-    result = runner.invoke(base_command, ['--help'])
+    result = runner.invoke(base_command, ["--help"])
 
     assert result.exit_code == 0
 

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -6,7 +6,7 @@ from loqusdb.exceptions import ProfileError
 
 def test_base_command():
     runner = CliRunner()
-    result = runner.invoke(base_command, [])
+    result = runner.invoke(base_command, ['--help'])
 
     assert result.exit_code == 0
 

--- a/tests/utils/test_profiling.py
+++ b/tests/utils/test_profiling.py
@@ -12,7 +12,7 @@ def test_get_profiles(real_mongo_adapter, profile_vcf_path, zipped_vcf_path):
     vcf_info = check_vcf(zipped_vcf_path)
 
     # Get profiles from vcf
-    profiles = get_profiles(real_mongo_adapter, zipped_vcf_path)
+    profiles = get_profiles(real_mongo_adapter, zipped_vcf_path, False)
 
     # Assert that all individuals are included
     assert list(profiles.keys()) == vcf_info["individuals"]

--- a/tests/vcf_tools/test_check_vcf.py
+++ b/tests/vcf_tools/test_check_vcf.py
@@ -47,7 +47,7 @@ def test_check_sv_vcf(sv_vcf_path):
                 true_nr += 1
 
     ## WHEN collecting the VCF info
-    vcf_info = check_vcf(sv_vcf_path, "sv")
+    vcf_info = check_vcf(sv_vcf_path, expected_type= "sv")
 
     ## THEN assert that the number of variants collected is correct
     assert vcf_info["nr_variants"] == true_nr

--- a/tests/vcf_tools/test_check_vcf.py
+++ b/tests/vcf_tools/test_check_vcf.py
@@ -47,7 +47,7 @@ def test_check_sv_vcf(sv_vcf_path):
                 true_nr += 1
 
     ## WHEN collecting the VCF info
-    vcf_info = check_vcf(sv_vcf_path, expected_type= "sv")
+    vcf_info = check_vcf(sv_vcf_path, expected_type="sv")
 
     ## THEN assert that the number of variants collected is correct
     assert vcf_info["nr_variants"] == true_nr

--- a/tests/vcf_tools/test_format_sv_variant.py
+++ b/tests/vcf_tools/test_format_sv_variant.py
@@ -25,6 +25,29 @@ def test_format_indel(del_variant, case_obj):
     assert formated_variant["homozygote"] == 0
     assert formated_variant["hemizygote"] == 0
 
+def test_format_indel_chrprefix(chr_del_variant, case_obj):
+    ## GIVEN a SV deletion
+    variant = chr_del_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+    expected_id = "_".join([variant.CHROM, str(variant.POS), variant.REF, variant.ALT[0]])
+
+    ## THEN assert the sv is parsed correct
+    assert formated_variant
+    assert formated_variant["variant_id"] == expected_id
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["end_chrom"] == variant.CHROM
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["end"] == variant.INFO["END"]
+    assert formated_variant["sv_len"] == abs(variant.INFO["SVLEN"])
+
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["sv_type"] == "DEL"
+    assert formated_variant["case_id"] == case_id
+    assert formated_variant["homozygote"] == 0
+    assert formated_variant["hemizygote"] == 0
 
 def test_format_small_ins(small_insert_variant, case_obj):
     ## GIVEN a small insertion (This means that the insertion is included in ALT field)
@@ -44,6 +67,23 @@ def test_format_small_ins(small_insert_variant, case_obj):
     assert formated_variant["alt"] == variant.ALT[0]
     assert formated_variant["sv_type"] == "INS"
 
+def test_format_small_ins_chrprefix(chr_small_insert_variant, case_obj):
+    ## GIVEN a small insertion (This means that the insertion is included in ALT field)
+    variant = chr_small_insert_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    ## THEN assert the sv is parsed correct
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["end_chrom"] == variant.CHROM
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["end"] == variant.POS + abs(variant.INFO["SVLEN"])
+    assert formated_variant["sv_len"] == abs(variant.INFO["SVLEN"])
+
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["sv_type"] == "INS"
 
 def test_format_insertion(insertion_variant, case_obj):
     ## GIVEN a small insertion (This means that the insertion is included in ALT field)
@@ -63,6 +103,23 @@ def test_format_insertion(insertion_variant, case_obj):
     assert formated_variant["alt"] == variant.ALT[0]
     assert formated_variant["sv_type"] == "INS"
 
+def test_format_insertion_chrprefix(chr_insertion_variant, case_obj):
+    ## GIVEN a small insertion (This means that the insertion is included in ALT field)
+    variant = chr_insertion_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    ## THEN assert the sv is parsed correct
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["end_chrom"] == variant.CHROM
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["end"] == variant.INFO["END"]
+    assert formated_variant["sv_len"] == 0
+
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["sv_type"] == "INS"
 
 def test_format_dup_tandem(duptandem_variant, case_obj):
     ## GIVEN a small insertion (This means that the insertion is included in ALT field)
@@ -82,6 +139,23 @@ def test_format_dup_tandem(duptandem_variant, case_obj):
     assert formated_variant["alt"] == variant.ALT[0]
     assert formated_variant["sv_type"] == "DUP"
 
+def test_format_dup_tandem_chrprefix(chr_duptandem_variant, case_obj):
+    ## GIVEN a small insertion (This means that the insertion is included in ALT field)
+    variant = chr_duptandem_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    ## THEN assert the sv is parsed correct
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["end_chrom"] == variant.CHROM
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["end"] == variant.INFO["END"]
+    assert formated_variant["sv_len"] == abs(variant.INFO["SVLEN"])
+
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["sv_type"] == "DUP"
 
 def test_format_translocation(translocation_variant, case_obj):
     ## GIVEN a small insertion (This means that the insertion is included in ALT field)
@@ -89,6 +163,24 @@ def test_format_translocation(translocation_variant, case_obj):
     case_id = case_obj["case_id"]
     ## WHEN parsing the variant
     formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id)
+
+    ## THEN assert the sv is parsed correct
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["end_chrom"] == "11"
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["end"] == 119123896
+    assert formated_variant["sv_len"] == float("inf")
+
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["sv_type"] == "BND"
+
+def test_format_translocation_chrprefix(chr_translocation_variant, case_obj):
+    ## GIVEN a small insertion (This means that the insertion is included in ALT field)
+    variant = chr_translocation_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
 
     ## THEN assert the sv is parsed correct
     assert formated_variant["chrom"] == variant.CHROM

--- a/tests/vcf_tools/test_format_variant.py
+++ b/tests/vcf_tools/test_format_variant.py
@@ -20,6 +20,24 @@ def test_format_variant(het_variant, case_obj):
     assert formated_variant["case_id"] == case_id
     assert formated_variant["homozygote"] == 0
 
+def test_format_variant_chrprefix(het_variant, case_obj):
+    ## GIVEN a parsed variant
+    variant = het_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    expected_id = "_".join([variant.CHROM, str(variant.POS), variant.REF, variant.ALT[0]])
+
+    ## THEN assert it was built in a correct way
+    assert formated_variant
+    assert formated_variant["variant_id"] == expected_id
+    assert formated_variant["chrom"] == variant.CHROM
+    assert formated_variant["pos"] == variant.POS
+    assert formated_variant["ref"] == variant.REF
+    assert formated_variant["alt"] == variant.ALT[0]
+    assert formated_variant["case_id"] == case_id
+    assert formated_variant["homozygote"] == 0
 
 def test_format_variant_no_qual(variant_no_gq, case_obj):
     ## GIVEN a variant without GQ
@@ -34,6 +52,18 @@ def test_format_variant_no_qual(variant_no_gq, case_obj):
     ## THEN assert that None is returned since requirements are not fulfilled
     assert formated_variant is None
 
+def test_format_variant_no_qual_chrprefix(variant_no_gq, case_obj):
+    ## GIVEN a variant without GQ
+    variant = variant_no_gq
+    ## And that has a missing QUAL value
+    variant.QUAL = None
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant using a QUAL threshold
+    formated_variant = build_variant(
+        variant=variant, case_obj=case_obj, case_id=case_id, gq_qual=True, gq_threshold=20, keep_chr_prefix=True
+    )
+    ## THEN assert that None is returned since requirements are not fulfilled
+    assert formated_variant is None
 
 def test_format_variant_no_gq(variant_no_gq, case_obj):
     ## GIVEN a variant without GQ
@@ -46,6 +76,16 @@ def test_format_variant_no_gq(variant_no_gq, case_obj):
     ## THEN assert that None is returned since requirements are not fulfilled
     assert formated_variant is None
 
+def test_format_variant_no_gq_chrprefix(variant_no_gq, case_obj):
+    ## GIVEN a variant without GQ
+    variant = variant_no_gq
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant using a GQ threshold
+    formated_variant = build_variant(
+        variant=variant, case_obj=case_obj, case_id=case_id, gq_threshold=20, keep_chr_prefix=True
+    )
+    ## THEN assert that None is returned since requirements are not fulfilled
+    assert formated_variant is None
 
 def test_format_variant_chr_prefix(variant_chr, case_obj):
     ## GIVEN a variant with 'chr' prefix in chromosome name
@@ -59,6 +99,17 @@ def test_format_variant_chr_prefix(variant_chr, case_obj):
     ## THEN assert that the 'chr' part has been stripped away
     assert formated_variant["chrom"] == variant.CHROM[3:]
 
+def test_format_variant_chr_prefix_chrprefix(variant_chr, case_obj):
+    ## GIVEN a variant with 'chr' prefix in chromosome name
+    variant = variant_chr
+    assert variant.CHROM.startswith("chr")
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant using a GQ threshold
+    formated_variant = build_variant(
+        variant=variant, case_obj=case_obj, case_id=case_id, gq_threshold=20, keep_chr_prefix=True
+    )
+    ## THEN assert that the 'chr' part has not been stripped away
+    assert formated_variant["chrom"] == variant.CHROM
 
 def test_format_variant_no_family_id(het_variant, case_obj):
     ## GIVEN a parsed variant
@@ -71,6 +122,16 @@ def test_format_variant_no_family_id(het_variant, case_obj):
     assert formated_variant["homozygote"] == 0
     assert formated_variant["hemizygote"] == 0
 
+def test_format_variant_no_family_id_chrprefix(het_variant, case_obj):
+    ## GIVEN a parsed variant
+    variant = het_variant
+    case_id = case_obj["case_id"]
+    ## WHEN parsing the variant telling that 'case_id' is None
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=None, keep_chr_prefix=True)
+    ## THEN assert that case_id was not added
+    assert formated_variant.get("case_id") == None
+    assert formated_variant["homozygote"] == 0
+    assert formated_variant["hemizygote"] == 0
 
 def test_format_homozygote_variant(hom_variant, case_obj):
     ## GIVEN a parsed hom variant
@@ -84,6 +145,17 @@ def test_format_homozygote_variant(hom_variant, case_obj):
     assert formated_variant["homozygote"] == 1
     assert formated_variant["hemizygote"] == 0
 
+def test_format_homozygote_variant_chrprefix(hom_variant, case_obj):
+    ## GIVEN a parsed hom variant
+    variant = hom_variant
+    case_id = case_obj["case_id"]
+
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    ## THEN assert that the variant has hom count
+    assert formated_variant["homozygote"] == 1
+    assert formated_variant["hemizygote"] == 0
 
 def test_format_hemizygote_variant(hem_variant, case_obj):
     ## GIVEN a parsed hemizygous variant
@@ -97,6 +169,17 @@ def test_format_hemizygote_variant(hem_variant, case_obj):
     assert formated_variant["homozygote"] == 0
     assert formated_variant["hemizygote"] == 1
 
+def test_format_hemizygote_variant_chrprefix(hem_variant, case_obj):
+    ## GIVEN a parsed hemizygous variant
+    variant = hem_variant
+    case_id = case_obj["case_id"]
+
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
+
+    ## THEN assert that hemizygote count is 1
+    assert formated_variant["homozygote"] == 0
+    assert formated_variant["hemizygote"] == 1
 
 def test_format_variant_no_call(variant_no_call, case_obj):
     ## GIVEN a parsed variant with no call in all individuals
@@ -108,6 +191,20 @@ def test_format_variant_no_call(variant_no_call, case_obj):
 
     ## WHEN parsing the variant
     formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id)
+
+    ## THEN assert that the result is None
+    assert formated_variant is None
+
+def test_format_variant_no_call_chrprefix(variant_no_call, case_obj):
+    ## GIVEN a parsed variant with no call in all individuals
+    variant = variant_no_call
+    case_id = case_obj["case_id"]
+
+    for call in variant.gt_types:
+        assert GENOTYPE_MAP[call] in ["no_call", "hom_ref"]
+
+    ## WHEN parsing the variant
+    formated_variant = build_variant(variant=variant, case_obj=case_obj, case_id=case_id, keep_chr_prefix=True)
 
     ## THEN assert that the result is None
     assert formated_variant is None


### PR DESCRIPTION
## Description

Added a flag to retain chr/CHR/Chr prefixes in the chromosome IDs when they are present

### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
