### PR TITLE
Update variant view command to check alternative chromosome representations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [unreleased]
+### Changed
+- variant query using the `variant` command will now check the database using alternative representations of the chromosome (with or without the 'chr' prefix) if the variant is not found with the provided representation.
+
 ## [2.7.20]
 ### Added
 - Representation of chromsomes from GRCh38

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -126,7 +126,7 @@ def variants(
     if end_chromosome:
         if end_chromosome.startswith("chr"):
             end_chromosomes = [end_chromosome, end_chromosome[3:]]
-        elif not chromosome.startswith("chr"):
+        elif not end_chromosome.startswith("chr"):
             end_chromosomes = [end_chromosome, "chr" + end_chromosome]
     else:
         end_chromosomes = [None, None]

--- a/loqusdb/commands/view.py
+++ b/loqusdb/commands/view.py
@@ -121,13 +121,13 @@ def variants(
         if chromosome.startswith("chr"):
             chromosomes = [chromosome, chromosome[3:]]
         elif not chromosome.startswith("chr"):
-            chromosomes = [chromosome, "chr"+chromosome]
+            chromosomes = [chromosome, "chr" + chromosome]
 
     if end_chromosome:
         if end_chromosome.startswith("chr"):
             end_chromosomes = [end_chromosome, end_chromosome[3:]]
         elif not chromosome.startswith("chr"):
-            end_chromosomes = [end_chromosome, "chr"+end_chromosome]
+            end_chromosomes = [end_chromosome, "chr" + end_chromosome]
     else:
         end_chromosomes = [None, None]
 
@@ -175,13 +175,15 @@ def variants(
             result = adapter.get_variants(chromosome=chromosomes[1], start=start, end=end)
     else:
         LOG.info("Search for svs")
-        result = list(adapter.get_sv_variants(
-            chromosome=chromosomes[0],
-            end_chromosome=end_chromosomes[0],
-            sv_type=sv_type,
-            pos=start,
-            end=end,
-        ))
+        result = list(
+            adapter.get_sv_variants(
+                chromosome=chromosomes[0],
+                end_chromosome=end_chromosomes[0],
+                sv_type=sv_type,
+                pos=start,
+                end=end,
+            )
+        )
         if len(result) == 0:
             result = adapter.get_sv_variants(
                 chromosome=chromosomes[1],
@@ -190,7 +192,6 @@ def variants(
                 pos=start,
                 end=end,
             )
-
 
     if to_json:
         json.dumps(variant)


### PR DESCRIPTION
## Description

variant query using the `variant` command will now check the database using alternative representations of the chromosome (with or without the 'chr' prefix) if the variant is not found with the provided representation.

Result from tests that were run locally:
![Screenshot 2025-06-02 at 15 55 47](https://github.com/user-attachments/assets/6409908d-c030-4aae-9701-c0545900f312)
![Screenshot 2025-06-02 at 16 13 41](https://github.com/user-attachments/assets/14e90548-2da0-49a5-abb5-3303d4b8ee59)


- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b [THIS-BRANCH-NAME]`

### How to test
- [ ] Do ...

### Expected test outcome
- [ ] Check that ...
- [ ] Take a screenshot and attach or copy/paste the output.

## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
