### PR TITLE
Update existing SNV collection with additional SNVs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
 ## [x.x.xx]
 ### Added
-- Added `--add-to-existing-snv` to append SNVs to an existing case without replacing its original SNV upload.
+- Added `loqusdb update --add-to-existing-snv` to append SNVs to an existing case without replacing its original SNV upload.
 
 ## [2.7.25]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ About changelog [here](https://keepachangelog.com/en/1.0.0/)
 ## [x.x.xx]
 ### Added
 - Added `loqusdb update --add-to-existing-snv` to append SNVs to an existing case without replacing its original SNV upload.
+- Added `--ignore-gq-if-unset` support to `loqusdb update`.
+### Changed
+- `loqusdb update` now accepts the global `--genome-build` and `--keep-chr-prefix` options.
 
 ## [2.7.25]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 About changelog [here](https://keepachangelog.com/en/1.0.0/)
 
+## [x.x.xx]
+### Added
+- Added `--add-to-existing-snv` to append SNVs to an existing case without replacing its original SNV upload.
+
 ## [2.7.25]
 ### Fixed
 - Update poetry lockfile with current versions of dependencies, fixing some issues that dependabot noticed

--- a/docs/user-guide/loading.md
+++ b/docs/user-guide/loading.md
@@ -14,6 +14,7 @@ It is possible to add a file after a case is loaded with `loqusdb update`
 To add another SNV VCF to a case that already has an SNV VCF, use
 `loqusdb update --add-to-existing-snv`. The existing case metadata and original
 SNV VCF are retained; variants from the new VCF are added to the database.
+Use `--ignore-gq-if-unset` when the update VCF does not define a GQ field.
 
 
 A case is loaded with:

--- a/docs/user-guide/loading.md
+++ b/docs/user-guide/loading.md
@@ -11,6 +11,10 @@ When loading a case for the first time one could do any of the following:
 
 It is possible to add a file after a case is loaded with `loqusdb update`
 
+To add another SNV VCF to a case that already has an SNV VCF, use
+`loqusdb load --add-to-existing-snv`. The existing case metadata and original
+SNV VCF are retained; variants from the new VCF are added to the database.
+
 
 A case is loaded with:
 
@@ -44,6 +48,8 @@ Options:
                                   (0-1)
   --soft-threshold FLOAT          profile hamming distance to store similar
                                   individuals (0-1)
+  --add-to-existing-snv           Add SNVs to an existing case without replacing
+                                  its stored SNV VCF
   --help                          Show this message and exit.
 ```
 

--- a/docs/user-guide/loading.md
+++ b/docs/user-guide/loading.md
@@ -12,7 +12,7 @@ When loading a case for the first time one could do any of the following:
 It is possible to add a file after a case is loaded with `loqusdb update`
 
 To add another SNV VCF to a case that already has an SNV VCF, use
-`loqusdb load --add-to-existing-snv`. The existing case metadata and original
+`loqusdb update --add-to-existing-snv`. The existing case metadata and original
 SNV VCF are retained; variants from the new VCF are added to the database.
 
 
@@ -48,8 +48,6 @@ Options:
                                   (0-1)
   --soft-threshold FLOAT          profile hamming distance to store similar
                                   individuals (0-1)
-  --add-to-existing-snv           Add SNVs to an existing case without replacing
-                                  its stored SNV VCF
   --help                          Show this message and exit.
 ```
 

--- a/loqusdb/__main__.py
+++ b/loqusdb/__main__.py
@@ -9,6 +9,7 @@ The main entry point for the command line interface.
 Invoke as ``loqusdb`` (if installed)
 or ``python -m loqusdb`` (no install required).
 """
+
 import sys
 
 from loqusdb.commands import base_command

--- a/loqusdb/build_models/profile_variant.py
+++ b/loqusdb/build_models/profile_variant.py
@@ -4,7 +4,6 @@ from loqusdb.build_models.variant import get_variant_id
 
 from loqusdb.models import ProfileVariant
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -102,6 +102,13 @@ def validate_profile_threshold(ctx, param, value):
     show_default=True,
     help="Ignore GQ threshold if GQ (or the QUAL field for --qual-gq) is unset in VCF",
 )
+@click.option(
+    "--add-to-existing-snv",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Add SNVs to an existing case without replacing its stored SNV VCF",
+)
 @click.pass_context
 def load(
     ctx,
@@ -120,6 +127,7 @@ def load(
     qual_gq,
     snv_gq_only,
     ignore_gq_if_unset,
+    add_to_existing_snv,
 ):
     """Load the variants of a case
 
@@ -132,6 +140,10 @@ def load(
 
     if not (variant_file or sv_variants):
         LOG.warning("Please provide a VCF file")
+        ctx.abort()
+
+    if add_to_existing_snv and (not variant_file or sv_variants):
+        LOG.warning("--add-to-existing-snv requires --variant-file and no --sv-variants")
         ctx.abort()
 
     variant_path = None
@@ -170,6 +182,7 @@ def load(
             soft_threshold=soft_threshold,
             genome_build=genome_build,
             ignore_gq_if_unset=ignore_gq_if_unset,
+            add_to_existing_snv=add_to_existing_snv,
         )
     except (SyntaxError, CaseError, IOError) as error:
         LOG.warning(error)

--- a/loqusdb/commands/load.py
+++ b/loqusdb/commands/load.py
@@ -102,13 +102,6 @@ def validate_profile_threshold(ctx, param, value):
     show_default=True,
     help="Ignore GQ threshold if GQ (or the QUAL field for --qual-gq) is unset in VCF",
 )
-@click.option(
-    "--add-to-existing-snv",
-    is_flag=True,
-    default=False,
-    show_default=True,
-    help="Add SNVs to an existing case without replacing its stored SNV VCF",
-)
 @click.pass_context
 def load(
     ctx,
@@ -127,7 +120,6 @@ def load(
     qual_gq,
     snv_gq_only,
     ignore_gq_if_unset,
-    add_to_existing_snv,
 ):
     """Load the variants of a case
 
@@ -140,10 +132,6 @@ def load(
 
     if not (variant_file or sv_variants):
         LOG.warning("Please provide a VCF file")
-        ctx.abort()
-
-    if add_to_existing_snv and (not variant_file or sv_variants):
-        LOG.warning("--add-to-existing-snv requires --variant-file and no --sv-variants")
         ctx.abort()
 
     variant_path = None
@@ -182,7 +170,6 @@ def load(
             soft_threshold=soft_threshold,
             genome_build=genome_build,
             ignore_gq_if_unset=ignore_gq_if_unset,
-            add_to_existing_snv=add_to_existing_snv,
         )
     except (SyntaxError, CaseError, IOError) as error:
         LOG.warning(error)

--- a/loqusdb/commands/update.py
+++ b/loqusdb/commands/update.py
@@ -62,6 +62,13 @@ LOG = logging.getLogger(__name__)
     show_default=True,
     help="Add SNVs to an existing case without replacing its stored SNV VCF",
 )
+@click.option(
+    "--ignore-gq-if-unset",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Ignore GQ threshold if GQ is unset in VCF",
+)
 @click.pass_context
 def update(
     ctx,
@@ -75,6 +82,7 @@ def update(
     ensure_index,
     max_window,
     add_to_existing_snv,
+    ignore_gq_if_unset,
 ):
     """Load the variants of a case
 
@@ -121,6 +129,7 @@ def update(
             genome_build=genome_build,
             keep_chr_prefix=keep_chr_prefix,
             add_to_existing_snv=add_to_existing_snv,
+            ignore_gq_if_unset=ignore_gq_if_unset,
         )
     except (SyntaxError, CaseError, IOError, VcfError) as error:
         LOG.warning(error)

--- a/loqusdb/commands/update.py
+++ b/loqusdb/commands/update.py
@@ -102,6 +102,8 @@ def update(
         variant_sv_path = os.path.abspath(sv_variants)
 
     adapter = ctx.obj["adapter"]
+    genome_build = ctx.obj["genome_build"]
+    keep_chr_prefix = ctx.obj["keep_chr_prefix"]
 
     start_inserting = datetime.now()
 
@@ -116,6 +118,8 @@ def update(
             case_id=case_id,
             gq_threshold=gq_threshold,
             max_window=max_window,
+            genome_build=genome_build,
+            keep_chr_prefix=keep_chr_prefix,
             add_to_existing_snv=add_to_existing_snv,
         )
     except (SyntaxError, CaseError, IOError, VcfError) as error:

--- a/loqusdb/commands/update.py
+++ b/loqusdb/commands/update.py
@@ -55,6 +55,13 @@ LOG = logging.getLogger(__name__)
     show_default=True,
     help="Specify the maximum window size for svs",
 )
+@click.option(
+    "--add-to-existing-snv",
+    is_flag=True,
+    default=False,
+    show_default=True,
+    help="Add SNVs to an existing case without replacing its stored SNV VCF",
+)
 @click.pass_context
 def update(
     ctx,
@@ -67,6 +74,7 @@ def update(
     case_id,
     ensure_index,
     max_window,
+    add_to_existing_snv,
 ):
     """Load the variants of a case
 
@@ -79,6 +87,10 @@ def update(
 
     if not (variant_file or sv_variants):
         LOG.warning("Please provide a VCF file")
+        ctx.abort()
+
+    if add_to_existing_snv and (not variant_file or sv_variants):
+        LOG.warning("--add-to-existing-snv requires --variant-file and no --sv-variants")
         ctx.abort()
 
     variant_path = None
@@ -104,6 +116,7 @@ def update(
             case_id=case_id,
             gq_threshold=gq_threshold,
             max_window=max_window,
+            add_to_existing_snv=add_to_existing_snv,
         )
     except (SyntaxError, CaseError, IOError, VcfError) as error:
         LOG.warning(error)

--- a/loqusdb/plugins/mongo/variant.py
+++ b/loqusdb/plugins/mongo/variant.py
@@ -4,7 +4,6 @@ from loqusdb.plugins.mongo.structural_variant import SVMixin
 
 from pymongo import ASCENDING, DESCENDING, DeleteOne, UpdateOne
 
-
 LOG = logging.getLogger(__name__)
 
 

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -138,7 +138,9 @@ def load_database(
         if not existing_case:
             raise CaseError("Case {0} does not exist in database".format(case_obj["case_id"]))
         if not existing_case.get("vcf_path"):
-            raise CaseError("Case {0} does not have an existing SNV VCF".format(case_obj["case_id"]))
+            raise CaseError(
+                "Case {0} does not have an existing SNV VCF".format(case_obj["case_id"])
+            )
 
         return load_variants(
             adapter=adapter,

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -41,7 +41,6 @@ def load_database(
     soft_threshold=0.9,
     genome_build=None,
     ignore_gq_if_unset=False,
-    add_to_existing_snv=False,
 ):
     """Load the database with a case and its variants
 
@@ -62,7 +61,6 @@ def load_database(
           soft_threshold(float): Stores similar samples if hamming distance above this is found
           genome_build(str): Store the genome version
           ignore_gq_if_unset(str): Ignore the gq threhsold check for variants that do not have a GQ or QUAL set
-          add_to_existing_snv(bool): Add SNVs without replacing the case's stored SNV VCF
 
     Returns:
           nr_inserted(int)
@@ -132,29 +130,6 @@ def load_database(
         matches=matches,
         profile_path=profile_file,
     )
-
-    if add_to_existing_snv:
-        existing_case = adapter.case(case_obj)
-        if not existing_case:
-            raise CaseError("Case {0} does not exist in database".format(case_obj["case_id"]))
-        if not existing_case.get("vcf_path"):
-            raise CaseError(
-                "Case {0} does not have an existing SNV VCF".format(case_obj["case_id"])
-            )
-
-        return load_variants(
-            adapter=adapter,
-            vcf_obj=get_vcf(variant_file),
-            case_obj=case_obj,
-            skip_case_id=skip_case_id,
-            gq_threshold=gq_threshold,
-            qual_gq=qual_gq,
-            keep_chr_prefix=keep_chr_prefix,
-            variant_type="snv",
-            genome_build=genome_build,
-            ignore_gq_if_unset=ignore_gq_if_unset,
-            skip_existing_case=True,
-        )
 
     # Build and load a new case, or update an existing one
     load_case(

--- a/loqusdb/utils/load.py
+++ b/loqusdb/utils/load.py
@@ -41,6 +41,7 @@ def load_database(
     soft_threshold=0.9,
     genome_build=None,
     ignore_gq_if_unset=False,
+    add_to_existing_snv=False,
 ):
     """Load the database with a case and its variants
 
@@ -61,6 +62,7 @@ def load_database(
           soft_threshold(float): Stores similar samples if hamming distance above this is found
           genome_build(str): Store the genome version
           ignore_gq_if_unset(str): Ignore the gq threhsold check for variants that do not have a GQ or QUAL set
+          add_to_existing_snv(bool): Add SNVs without replacing the case's stored SNV VCF
 
     Returns:
           nr_inserted(int)
@@ -130,6 +132,28 @@ def load_database(
         matches=matches,
         profile_path=profile_file,
     )
+
+    if add_to_existing_snv:
+        existing_case = adapter.case(case_obj)
+        if not existing_case:
+            raise CaseError("Case {0} does not exist in database".format(case_obj["case_id"]))
+        if not existing_case.get("vcf_path"):
+            raise CaseError("Case {0} does not have an existing SNV VCF".format(case_obj["case_id"]))
+
+        return load_variants(
+            adapter=adapter,
+            vcf_obj=get_vcf(variant_file),
+            case_obj=case_obj,
+            skip_case_id=skip_case_id,
+            gq_threshold=gq_threshold,
+            qual_gq=qual_gq,
+            keep_chr_prefix=keep_chr_prefix,
+            variant_type="snv",
+            genome_build=genome_build,
+            ignore_gq_if_unset=ignore_gq_if_unset,
+            skip_existing_case=True,
+        )
+
     # Build and load a new case, or update an existing one
     load_case(
         adapter=adapter,
@@ -208,6 +232,7 @@ def load_variants(
     variant_type="snv",
     genome_build=None,
     ignore_gq_if_unset=False,
+    skip_existing_case=False,
 ):
     """Load variants for a family into the database.
 
@@ -262,6 +287,14 @@ def load_variants(
             nr_inserted += 1
 
     if variant_type == "snv":
+        if skip_existing_case:
+            variants = (
+                variant
+                for variant in variants
+                if variant
+                and case_obj["case_id"]
+                not in (adapter.get_variant(variant) or {}).get("families", [])
+            )
         nr_inserted = adapter.add_variants(variants)
 
     LOG.info("Inserted %s variants of type %s", nr_inserted, variant_type)

--- a/loqusdb/utils/update.py
+++ b/loqusdb/utils/update.py
@@ -34,6 +34,7 @@ def update_database(
     genome_build=None,
     keep_chr_prefix=False,
     add_to_existing_snv=False,
+    ignore_gq_if_unset=False,
 ):
     """Update a case in the database
 
@@ -50,6 +51,7 @@ def update_database(
           genome_build(str): Genome version
           keep_chr_prefix(bool): Retain chr/CHR/Chr prefixes when present
           add_to_existing_snv(bool): Add SNVs without replacing the case's stored SNV VCF
+          ignore_gq_if_unset(bool): Ignore GQ threshold when GQ is unset in VCF
 
     Returns:
           nr_inserted(int)
@@ -78,7 +80,7 @@ def update_database(
         # Get a cyvcf2.VCF object
         vcf = get_vcf(_vcf_file)
 
-        if gq_threshold:
+        if gq_threshold and not ignore_gq_if_unset:
             if not vcf.contains("GQ"):
                 LOG.warning("Set gq-threshold to 0 or add info to vcf {0}".format(_vcf_file))
                 raise SyntaxError("GQ is not defined in vcf header")
@@ -124,6 +126,7 @@ def update_database(
             gq_threshold=gq_threshold,
             keep_chr_prefix=keep_chr_prefix,
             genome_build=genome_build,
+            ignore_gq_if_unset=ignore_gq_if_unset,
             variant_type="snv",
             skip_existing_case=True,
         )
@@ -158,6 +161,7 @@ def update_database(
                 gq_threshold=gq_threshold,
                 keep_chr_prefix=keep_chr_prefix,
                 genome_build=genome_build,
+                ignore_gq_if_unset=ignore_gq_if_unset,
                 max_window=max_window,
                 variant_type=variant_type,
             )

--- a/loqusdb/utils/update.py
+++ b/loqusdb/utils/update.py
@@ -31,6 +31,8 @@ def update_database(
     gq_threshold=None,
     case_id=None,
     max_window=3000,
+    genome_build=None,
+    keep_chr_prefix=False,
     add_to_existing_snv=False,
 ):
     """Update a case in the database
@@ -45,6 +47,8 @@ def update_database(
           gq_threshold(int): If only quality variants should be considered
           case_id(str): If different case id than the one in family file should be used
           max_window(int): Specify the max size for sv windows
+          genome_build(str): Genome version
+          keep_chr_prefix(bool): Retain chr/CHR/Chr prefixes when present
           add_to_existing_snv(bool): Add SNVs without replacing the case's stored SNV VCF
 
     Returns:
@@ -54,7 +58,7 @@ def update_database(
     nr_variants = None
     vcf_individuals = None
     if variant_file:
-        vcf_info = check_vcf(variant_file)
+        vcf_info = check_vcf(variant_file, keep_chr_prefix)
         nr_variants = vcf_info["nr_variants"]
         variant_type = vcf_info["variant_type"]
         vcf_files.append(variant_file)
@@ -64,7 +68,7 @@ def update_database(
     nr_sv_variants = None
     sv_individuals = None
     if sv_file:
-        vcf_info = check_vcf(sv_file, "sv")
+        vcf_info = check_vcf(sv_file, keep_chr_prefix, "sv")
         nr_sv_variants = vcf_info["nr_variants"]
         vcf_files.append(sv_file)
         sv_individuals = vcf_info["individuals"]
@@ -118,6 +122,8 @@ def update_database(
             case_obj=case_obj,
             skip_case_id=skip_case_id,
             gq_threshold=gq_threshold,
+            keep_chr_prefix=keep_chr_prefix,
+            genome_build=genome_build,
             variant_type="snv",
             skip_existing_case=True,
         )
@@ -150,6 +156,8 @@ def update_database(
                 case_obj=case_obj,
                 skip_case_id=skip_case_id,
                 gq_threshold=gq_threshold,
+                keep_chr_prefix=keep_chr_prefix,
+                genome_build=genome_build,
                 max_window=max_window,
                 variant_type=variant_type,
             )

--- a/loqusdb/utils/update.py
+++ b/loqusdb/utils/update.py
@@ -31,6 +31,7 @@ def update_database(
     gq_threshold=None,
     case_id=None,
     max_window=3000,
+    add_to_existing_snv=False,
 ):
     """Update a case in the database
 
@@ -44,6 +45,7 @@ def update_database(
           gq_threshold(int): If only quality variants should be considered
           case_id(str): If different case id than the one in family file should be used
           max_window(int): Specify the max size for sv windows
+          add_to_existing_snv(bool): Add SNVs without replacing the case's stored SNV VCF
 
     Returns:
           nr_inserted(int)
@@ -103,6 +105,26 @@ def update_database(
     existing_case = adapter.case(case_obj)
     if not existing_case:
         raise CaseError("Case {} does not exist in database".format(case_obj["case_id"]))
+
+    if add_to_existing_snv:
+        if not existing_case.get("vcf_path"):
+            raise CaseError(
+                "Case {0} does not have an existing SNV VCF".format(case_obj["case_id"])
+            )
+
+        nr_inserted = load_variants(
+            adapter=adapter,
+            vcf_obj=get_vcf(variant_file),
+            case_obj=case_obj,
+            skip_case_id=skip_case_id,
+            gq_threshold=gq_threshold,
+            variant_type="snv",
+            skip_existing_case=True,
+        )
+        existing_case["nr_variants"] = existing_case.get("nr_variants") or 0
+        existing_case["nr_variants"] += nr_inserted
+        adapter.add_case(existing_case, update=True)
+        return nr_inserted
 
     # Update the existing case in database
     case_obj = load_case(

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -24,6 +24,22 @@ def test_load_command(vcf_path, ped_path, real_mongo_adapter, real_db_name):
     assert sum([1 for case in real_mongo_adapter.cases()]) == 1
 
 
+def test_load_command_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, real_db_name):
+    runner = CliRunner()
+    load_command = ["--database", real_db_name, "load", "--variant-file", vcf_path, "-f", ped_path]
+    result = runner.invoke(base_command, load_command)
+    assert result.exit_code == 0
+
+    case_before = dict(real_mongo_adapter.db.case.find_one())
+    result = runner.invoke(
+        base_command,
+        load_command + ["--add-to-existing-snv"],
+    )
+
+    assert result.exit_code == 0
+    assert real_mongo_adapter.case({"case_id": case_before["case_id"]}) == case_before
+
+
 def test_load_command_no_ped_case_id(vcf_path, case_id, real_mongo_adapter, real_db_name):
     ## GIVEN a vcf_path a ped_path and a empty database
     assert real_mongo_adapter.case({"case_id": case_id}) is None

--- a/tests/functional/test_cli.py
+++ b/tests/functional/test_cli.py
@@ -24,7 +24,7 @@ def test_load_command(vcf_path, ped_path, real_mongo_adapter, real_db_name):
     assert sum([1 for case in real_mongo_adapter.cases()]) == 1
 
 
-def test_load_command_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, real_db_name):
+def test_update_command_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, real_db_name):
     runner = CliRunner()
     load_command = ["--database", real_db_name, "load", "--variant-file", vcf_path, "-f", ped_path]
     result = runner.invoke(base_command, load_command)
@@ -33,7 +33,16 @@ def test_load_command_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter
     case_before = dict(real_mongo_adapter.db.case.find_one())
     result = runner.invoke(
         base_command,
-        load_command + ["--add-to-existing-snv"],
+        [
+            "--database",
+            real_db_name,
+            "update",
+            "--variant-file",
+            vcf_path,
+            "-f",
+            ped_path,
+            "--add-to-existing-snv",
+        ],
     )
 
     assert result.exit_code == 0

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -152,9 +152,7 @@ def test_update_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case
     )
 
 
-def test_update_ignore_gq_if_unset(
-    vcf_path, ped_path, real_mongo_adapter, case_id, profile_vcf_path
-):
+def test_update_ignore_gq_if_unset(vcf_path, ped_path, real_mongo_adapter, case_id, tmp_path):
     load_database(
         adapter=real_mongo_adapter,
         variant_file=vcf_path,
@@ -162,10 +160,19 @@ def test_update_ignore_gq_if_unset(
         family_type="ped",
         genome_build=GRCH37,
     )
+    no_gq_vcf = tmp_path / "no-gq.vcf"
+    with open(vcf_path) as original_vcf:
+        no_gq_content = original_vcf.read()
+    no_gq_content = no_gq_content.replace(
+        '##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">\n', ""
+    )
+    no_gq_content = no_gq_content.replace("GT:AD:GQ", "GT:AD").replace(":60", "")
+    with open(no_gq_vcf, "w") as no_gq_file:
+        no_gq_file.write(no_gq_content)
 
     nr_inserted = update_database(
         adapter=real_mongo_adapter,
-        variant_file=profile_vcf_path,
+        variant_file=str(no_gq_vcf),
         case_id=case_id,
         gq_threshold=20,
         genome_build=GRCH37,

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -125,7 +125,8 @@ def test_update_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case
     with open(vcf_path) as original_vcf:
         original_vcf_content = original_vcf.read()
     additional_vcf.write_text(
-        original_vcf_content
+        original_vcf_content.rstrip("\n")
+        + "\n"
         + "1\t999999\t.\tA\tC\t100\tPASS\tMQ=1\tGT:AD:GQ\t"
         + "\t".join(["0/1:10,10:60"] * 6)
         + "\n"

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -106,3 +106,36 @@ def test_load_database_wrong_ped_grch38(vcf_path, funny_ped_path, real_mongo_ada
             family_type="ped",
             genome_build=GRCH38,
         )
+
+
+def test_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case_id):
+    mongo_adapter = real_mongo_adapter
+
+    load_database(
+        adapter=mongo_adapter,
+        variant_file=vcf_path,
+        family_file=ped_path,
+        family_type="ped",
+        genome_build=GRCH37,
+    )
+    existing_case = dict(mongo_adapter.case({"case_id": case_id}))
+    existing_variants = list(mongo_adapter.db.variant.find())
+
+    nr_inserted = load_database(
+        adapter=mongo_adapter,
+        variant_file=vcf_path,
+        family_file=ped_path,
+        family_type="ped",
+        genome_build=GRCH37,
+        add_to_existing_snv=True,
+    )
+
+    assert nr_inserted == 0
+    assert mongo_adapter.case({"case_id": case_id}) == existing_case
+    updated_variants = {
+        variant["_id"]: variant for variant in mongo_adapter.db.variant.find()
+    }
+    assert all(
+        updated_variants[variant["_id"]]["observations"] == variant["observations"]
+        for variant in existing_variants
+    )

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -150,3 +150,27 @@ def test_update_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case
         updated_variants[variant["_id"]]["observations"] == variant["observations"]
         for variant in existing_variants
     )
+
+
+def test_update_ignore_gq_if_unset(
+    vcf_path, ped_path, real_mongo_adapter, case_id, profile_vcf_path
+):
+    load_database(
+        adapter=real_mongo_adapter,
+        variant_file=vcf_path,
+        family_file=ped_path,
+        family_type="ped",
+        genome_build=GRCH37,
+    )
+
+    nr_inserted = update_database(
+        adapter=real_mongo_adapter,
+        variant_file=profile_vcf_path,
+        case_id=case_id,
+        gq_threshold=20,
+        genome_build=GRCH37,
+        add_to_existing_snv=True,
+        ignore_gq_if_unset=True,
+    )
+
+    assert nr_inserted == 0

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -136,6 +136,7 @@ def test_update_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case
         variant_file=str(additional_vcf),
         family_file=ped_path,
         family_type="ped",
+        genome_build=GRCH37,
         add_to_existing_snv=True,
     )
 

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -1,6 +1,7 @@
 import pytest
 from loqusdb.exceptions import CaseError
 from loqusdb.utils.load import load_database
+from loqusdb.utils.update import update_database
 from loqusdb.constants import GRCH37, GRCH38
 
 
@@ -108,7 +109,7 @@ def test_load_database_wrong_ped_grch38(vcf_path, funny_ped_path, real_mongo_ada
         )
 
 
-def test_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case_id):
+def test_update_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case_id, tmp_path):
     mongo_adapter = real_mongo_adapter
 
     load_database(
@@ -120,18 +121,28 @@ def test_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case_id):
     )
     existing_case = dict(mongo_adapter.case({"case_id": case_id}))
     existing_variants = list(mongo_adapter.db.variant.find())
+    additional_vcf = tmp_path / "additional.vcf"
+    with open(vcf_path) as original_vcf:
+        original_vcf_content = original_vcf.read()
+    additional_vcf.write_text(
+        original_vcf_content
+        + "1\t999999\t.\tA\tC\t100\tPASS\tMQ=1\tGT:AD:GQ\t"
+        + "\t".join(["0/1:10,10:60"] * 6)
+        + "\n"
+    )
 
-    nr_inserted = load_database(
+    nr_inserted = update_database(
         adapter=mongo_adapter,
-        variant_file=vcf_path,
+        variant_file=str(additional_vcf),
         family_file=ped_path,
         family_type="ped",
-        genome_build=GRCH37,
         add_to_existing_snv=True,
     )
 
-    assert nr_inserted == 0
-    assert mongo_adapter.case({"case_id": case_id}) == existing_case
+    assert nr_inserted == 1
+    updated_case = mongo_adapter.case({"case_id": case_id})
+    assert updated_case["nr_variants"] == existing_case["nr_variants"] + nr_inserted
+    assert updated_case["vcf_path"] == existing_case["vcf_path"]
     updated_variants = {variant["_id"]: variant for variant in mongo_adapter.db.variant.find()}
     assert all(
         updated_variants[variant["_id"]]["observations"] == variant["observations"]

--- a/tests/utils/test_load_database.py
+++ b/tests/utils/test_load_database.py
@@ -132,9 +132,7 @@ def test_add_to_existing_snv(vcf_path, ped_path, real_mongo_adapter, case_id):
 
     assert nr_inserted == 0
     assert mongo_adapter.case({"case_id": case_id}) == existing_case
-    updated_variants = {
-        variant["_id"]: variant for variant in mongo_adapter.db.variant.find()
-    }
+    updated_variants = {variant["_id"]: variant for variant in mongo_adapter.db.variant.find()}
     assert all(
         updated_variants[variant["_id"]]["observations"] == variant["observations"]
         for variant in existing_variants


### PR DESCRIPTION
## Description
This PR adds the option to update an existing set of SNVs with additional SNVs, without modifying the already uploaded variants. This is a solution for uploading MT variants of cases that have already been run, but did not have their MT variants uploaded (https://github.com/Clinical-Genomics/MTP-RAREDISEASE/issues/172). We do not want to reupload all these cases, only to add to them.

This should run as:
```
loqusdb update \
  --variant-file additional.vcf \
  --family-file case.ped \
  --add-to-existing-snv
```

### Added
- Added `loqusdb update --add-to-existing-snv` to append SNVs to an existing case without replacing its original SNV upload.
- Added `--ignore-gq-if-unset` support to `loqusdb update`.
### Changed
- `loqusdb update` now accepts the global `--genome-build` and `--keep-chr-prefix` options.


### How to prepare for test
- [ ] ssh to hasta.scilifelab.se
- [ ] Use stage: `us`
- [ ] Paxa the environment: `paxa`
- [ ] Install on stage (example for hasta):
`bash /home/proj/production/servers/resources/hasta.scilifelab.se/update-tool-stage.sh -e S_loqusdb -t loqusdb -b update-existing-snv-variants`

### How to test
- [ ] Do regular upload of NIST sample: 
`/home/proj/stage/bin/miniconda3/envs/S_loqusdb/bin/loqusdb --config /home/proj/stage/servers/config/hasta.scilifelab.se/loqusdb-wgs-stage.yaml --keep-chr-prefix --genome-build GRCh38 load --case-id evolvedsalmon --variant-file /home/proj/production/housekeeper-bundles/evolvedsalmon/2026-05-13/evolvedsalmon_snv_ranked_clinical.vcf.gz --check-profile /home/proj/production/housekeeper-bundles/evolvedsalmon/2026-05-13/evolvedsalmon_snv_ranked_clinical.vcf.gz --family-file /home/proj/production/housekeeper-bundles/evolvedsalmon/2026-05-13/evolvedsalmon.ped --gq-threshold 10 --hard-threshold 0.95 --soft-threshold 0.9`

- [ ] Do the addition with the new flag --add-to-existing-snv:
`/home/proj/stage/bin/miniconda3/envs/S_loqusdb/bin/loqusdb --config /home/proj/stage/servers/config/hasta.scilifelab.se/loqusdb-wgs-stage.yaml --keep-chr-prefix --genome-build GRCh38 update --case-id evolvedsalmon --variant-file /home/proj/production/housekeeper-bundles/evolvedsalmon/2026-05-13/evolvedsalmon_mt_ranked_clinical.vcf.gz --family-file /home/proj/production/housekeeper-bundles/evolvedsalmon/2026-05-13/evolvedsalmon.ped --ignore-gq-if-unset --add-to-existing-snv`

### Expected test outcome
- [ ] Check that the case uploads
<img width="1355" height="564" alt="image" src="https://github.com/user-attachments/assets/88c34df5-63ce-4b1e-9b44-fa6f752a28fc" />

- [ ] The addition adds the new MT variants when using loqusdb update with --add-to-existing-snv:
<img width="1354" height="460" alt="image" src="https://github.com/user-attachments/assets/6e342814-402d-416f-8c2f-6ab83e0ad287" />

Checking in MongoDB compass shows the number of variants in the DB to be 608989, which is the 608974 of the SNV upload + the 15 of the MT upload.
<img width="226" height="67" alt="image" src="https://github.com/user-attachments/assets/c50c1f8a-9c12-4d0a-aefb-0eb6cb108cb5" />

Query mongoDB to show MT variants added:
```
{
  _id: "$chrom",
  count: {
    $sum: 1
  }
}
```

<img width="182" height="280" alt="image" src="https://github.com/user-attachments/assets/603b9219-96f3-4806-bff3-e9df7bc1ad17" />

Bonus test, the case variants should have been updated to the new number:
After loqusDB load it shows the nr of variants in the VCF:
<img width="640" height="93" alt="image" src="https://github.com/user-attachments/assets/c2332a80-9be6-42d7-a4e7-95db23e223a4" />

After loqusdb update it shows the number of variants in the VCF + MT VCF:
<img width="714" height="243" alt="image" src="https://github.com/user-attachments/assets/d529de4b-64e1-49f5-8a9c-4c4eefbcabf0" />



## Review
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

### This [version](https://semver.org/) is a
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Implementation Plan
- [ ] Document in ...
- [ ] Deploy this branch
- [ ] Inform to ...
